### PR TITLE
Remediate the security review findings (#41–#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,6 +353,93 @@ And four more in the broker's own defaults:
   an administrator, not by this unit. Removed, leaving `ProtectSystem=strict` to
   keep `/etc` read-only.
 
+- **`refresh_session` extended expired sessions and re-inserted revoked ones.**
+  `RefreshSession` had no expiry check at all — `time.Until` of a past instant is
+  simply negative, so an expired session fell through to the extend branch and
+  came back `success: true`, `status: "authorized"`, with the mapped `user_id` and
+  a fresh hour on it. `check_session` has always refused that, so the two verbs
+  disagreed and a client could route around its own expiry by choosing which one
+  to send. An expired session is now removed and answered `SESSION_EXPIRED`, the
+  same as `check_session`.
+
+  The extension also wrote a whole snapshot back into the session map with no
+  compare-and-set, so a `revoke_session` or a cleanup pass that deleted the
+  session between the read and the write was silently undone — resurrecting a
+  session whose token had already been destroyed at the provider, with no poller
+  and nothing left to clean it up before its brand-new expiry. Measured: 1 of 200
+  unassisted attempts, and `-race` reports nothing, because every access is
+  correctly locked and the wrong value is written. Extension now goes through a
+  compare-and-set shaped like the one that guards activation: it takes the lock,
+  re-reads the live entry, and refuses unless it is still the same authorized
+  session. A refresh also re-checks that the session's token still resolves, which
+  catches the same fact independently. Both proofs are in-tree —
+  `TestRefreshRefusesExpiredAuthorizedSession`,
+  `TestExtendSessionRefusesUnlessStillTheSameAuthorizedSession` and
+  `TestRefreshDoesNotResurrectRevokedSession` in
+  `pkg/auth/refresh_test.go`, plus `TestRefreshRefusesExpiredSessionOnTheWire`
+  over a real socket — and each one was checked against the unfixed code.
+
+  No in-tree client sends `refresh_session`: the PAM module sends only
+  `authenticate` and `check_session`, so this was not a live privilege escalation.
+  It was a latent authorization defect in a verb
+  [docs/wire-protocol.md](docs/wire-protocol.md) makes normative for other
+  implementations, which is why the spec now states both refusals.
+  ([#41](https://github.com/scttfrdmn/oauth2-pam/issues/41))
+
+- **`security.max_token_age` was validated and never enforced.** It was parsed,
+  defaulted to 24h, documented in `configs/example.yaml`, and read in exactly one
+  place: a startup check that `token_lifetime` does not exceed it. Nothing ever
+  compared a session's age against it, so an operator reading it as a hard cap on
+  how old a session may get had a lint rule on their config file. Measured with
+  the ceiling at 2s: fifty consecutive refreshes all succeeded, and the session's
+  `expires_at` ended an hour past a `created_at` that never moved. A session past
+  the ceiling is now revoked rather than extended — in the refresh path and in the
+  periodic session sweep, since nothing calls `refresh_session` on most sessions
+  and a ceiling enforced only there would not be one. Measured from `CreatedAt`,
+  which no extension moves; `0` still means unset. The boundary is asserted in
+  both directions so the comparison cannot be quietly inverted.
+  ([#43](https://github.com/scttfrdmn/oauth2-pam/issues/43))
+
+- **A provider could draw on the pre-authentication terminal.** A device flow's
+  `verification_uri` and `user_code` are chosen by the provider, travel over IPC,
+  and are printed to the tty by a root process before anyone has authenticated —
+  unfiltered. For `github.com` that is theoretical; for a configured Enterprise
+  `base_url` it is not, because that server picks what every host configured
+  against it draws on screen. A payload of `ESC[2J ESC[H` and a fake `Password:`
+  prompt is enough to harvest a Unix password from a user who believes they are
+  still talking to `sshd`.
+
+  Provider-supplied strings are now stripped of C0, DEL, C1 (including U+009B,
+  where CSI hides in UTF-8) and U+2028/9 as they enter a response, and an altered
+  value is marked so the operator can see something was removed rather than
+  silently receiving a mangled URL. Stripping rather than escaping is deliberate:
+  the module copies `instructions` into a fixed 16 KiB buffer that truncates
+  silently, so an escaping filter — up to 6× expansion — would let a provider pad
+  the prompt until the trusted trailer fell off the end. `TestSanitizingCannotAmplify`
+  pins that. Sanitizing happens at the point the values enter an `AuthResponse`,
+  not in the prompt formatters, because `device_url` and `device_code` also go on
+  the wire as their own fields that
+  [docs/wire-protocol.md](docs/wire-protocol.md) offers to "a client that wants to
+  format its own prompt" — cleaning only this implementation's formatters would
+  have left a consumer holding raw bytes. Bidi and zero-width characters are
+  deliberately not filtered: they cannot move a cursor, and denying them would
+  break legitimate non-Latin text.
+  ([#45](https://github.com/scttfrdmn/oauth2-pam/issues/45))
+
+- **The session rate limiter grew without bound, and session requests cost an
+  unknown caller nothing.** The five-minute eviction sweep cleaned only the
+  per-UID limiter — the one whose key space is the host's own UIDs, and therefore
+  tiny. The one it missed is keyed on the `session_id` in the request, which a
+  caller chooses: `allow` allocates a window on first sight of any key and never
+  required the session to exist, so 3000 requests naming 3000 invented sessions
+  left 3000 permanent windows, none of them refused, at roughly 14k requests a
+  second. The sweep now reaches every limiter, and *introducing* a previously
+  unseen session ID is charged to the calling UID — introducing one is the only
+  part of a session request whose cost outlives the reply. Polling an established
+  session stays free to the caller, which is what keeps the fix for the host-wide
+  polling DoS above intact. A key ceiling backstops both.
+  ([#42](https://github.com/scttfrdmn/oauth2-pam/issues/42))
+
 ### Changed
 
 - **Mapper `groups` stay advisory, and are no longer advisory *quietly*.** The
@@ -527,6 +614,37 @@ And four more in the broker's own defaults:
   advisories reachable from this code, and no 1.24.x pin could ever clear them.
   govulncheck reports zero under 1.25. The pin is the language version rather than
   a patch release, so any 1.25.x toolchain satisfies it.
+- **`oauth2-pam-enroll` refuses a local account the mapper would refuse anyway.**
+  Enrollment is tier 0 of the mapping chain and its answer has always passed the
+  same gate as every other tier, so a record naming `root` or a system account
+  failed closed at login — this was never a bypass. It was a bad error at a bad
+  time: the operator learned of it as a denied login rather than as a refusal when
+  they typed the name. The check now runs *before* the device flow, so nobody
+  authorizes in a browser for a name that cannot work. `pkg/enrollment` cannot
+  import `pkg/mapper` (the dependency runs the other way), so the rules are
+  injected rather than copied — a copy could drift from the mapper's silently — and
+  `Add` takes the validator as a **required** parameter with a named `Unvalidated`
+  sentinel, so a future caller has to choose to skip the gate rather than default
+  into it. A store that already contains a forbidden record still loads and can
+  still be repaired; validating on load would turn one unusable enrollment into an
+  unrepairable file. ([#46](https://github.com/scttfrdmn/oauth2-pam/issues/46))
+- **The socket's trust boundary is stated instead of implied.** `internal/ipc`
+  described a group-based access model — "root-owned, group oauth2-pam", "must run
+  as a member of the oauth2-pam group" — that nothing implements: there is no
+  `os.Chown` in the repository, no packaging artifact creates the group, and the
+  unit runs `User=root`/`Group=root`. Reality was *safer* than the comment, which
+  is what made it worth fixing: a reader following the comment would have created
+  the group and widened the boundary without the ownership work that model needs.
+  The comments, the systemd unit and `docs/wire-protocol.md` now say what is true —
+  the broker socket is reachable by root and nobody else, the PAM module qualifies
+  because it runs inside `sshd`'s pre-auth child, and several accepted risks in this
+  project are accepted *only* because that caller can only be root. Anyone who
+  changes that has to re-rate those findings first, and the note says so.
+  `TestSocketPermissions` now asserts the containing directory as well as the
+  socket. ([#44](https://github.com/scttfrdmn/oauth2-pam/issues/44))
+- **Spec correction:** `refresh_session` never exchanged an OAuth2 refresh token,
+  and no implementation ever did; earlier revisions of `docs/wire-protocol.md` said
+  it did. It moves the broker's own `expires_at`, with no provider round trip.
 
 ## [0.2.0] - 2026-08-13
 

--- a/cmd/oauth2-pam-enroll/main.go
+++ b/cmd/oauth2-pam-enroll/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/scttfrdmn/oauth2-pam/pkg/config"
 	"github.com/scttfrdmn/oauth2-pam/pkg/enrollment"
+	"github.com/scttfrdmn/oauth2-pam/pkg/mapper"
 	"github.com/scttfrdmn/oauth2-pam/pkg/provider"
 	"github.com/scttfrdmn/oauth2-pam/pkg/provider/registry"
 )
@@ -160,9 +161,49 @@ func runRemove(localUser, enrollFile string) error {
 	return nil
 }
 
+// localUserGate returns the check a local username has to pass to be enrolled:
+// the mapper's, taken from the mapper configuration this host will authenticate
+// with, so the answer here is the answer the login will get. Because the config is
+// loaded (mapper.min_uid included) the full gate applies, not just the parts that
+// need no configuration.
+//
+// The error explains the rule rather than only refusing it, and says where the
+// rule comes from — an operator who is told "no" by a tool that is not the one
+// that will deny the login has no way to guess why.
+func localUserGate(cfg *config.Config) enrollment.LocalUserValidator {
+	chain := mapper.New(cfg.Mapper)
+	return func(localUser string) error {
+		if err := chain.ValidateLocalUser("enrollment", localUser); err != nil {
+			return fmt.Errorf("%w\n\n"+
+				"This is the same local-account gate the mapper applies to every tier at\n"+
+				"login, so %q could not authenticate even once enrolled. To be enrollable a\n"+
+				"local user must:\n"+
+				"  - be a valid Unix name: a lowercase letter or underscore, then lowercase\n"+
+				"    letters, digits, hyphens or underscores, at most 32 characters\n"+
+				"  - not be root, and not be a system or service account (if a real person on\n"+
+				"    this host has such a name, list it in mapper.allow_system_users; nothing\n"+
+				"    exempts root)\n"+
+				"  - have a UID at or above mapper.min_uid, when the account resolves here",
+				err, localUser)
+		}
+		return nil
+	}
+}
+
 // runEnroll runs the Device Flow, confirms the provider identity, and writes
 // the enrollment record.
 func runEnroll(localUser, providerName string, groups []string, enrollFile string, cfg *config.Config) error {
+	// The mapper's own local-account gate, applied here before anything else
+	// happens. mapper.Map already refuses tier 0 answers that do not pass it, so an
+	// enrollment naming root, a system account, or an account below
+	// mapper.min_uid can never authenticate; writing it would only turn a typo into
+	// a denied login days later. Checked before the device flow so the operator is
+	// not sent to a browser to authorize a record that will be rejected.
+	validateLocalUser := localUserGate(cfg)
+	if err := validateLocalUser(localUser); err != nil {
+		return err
+	}
+
 	// Verify the local Unix user exists before starting the device flow.
 	if _, err := user.Lookup(localUser); err != nil {
 		return fmt.Errorf("local user %q not found: %w", localUser, err)
@@ -232,7 +273,9 @@ func runEnroll(localUser, providerName string, groups []string, enrollFile strin
 		Groups:     groups,
 	}
 
-	if err := store.Add(rec); err != nil {
+	// The gate again, at the store: the check above is for the operator, this one
+	// is what a future writer of this file inherits.
+	if err := store.Add(rec, validateLocalUser); err != nil {
 		return fmt.Errorf("add enrollment: %w", err)
 	}
 

--- a/cmd/oauth2-pam-enroll/main_test.go
+++ b/cmd/oauth2-pam-enroll/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/oauth2-pam/pkg/config"
+	"github.com/scttfrdmn/oauth2-pam/pkg/mapper"
+)
+
+// testConfig is enough config to reach the gate: a provider so the command has
+// something to enroll against, and the mapper defaults LoadConfig would have
+// applied. The device flow is never started in these tests, because the gate runs
+// first — which is the point of where it was put.
+func testConfig() *config.Config {
+	return &config.Config{
+		Providers: []config.ProviderConfig{{
+			Name:         "gh",
+			Type:         "github",
+			ClientID:     "id",
+			ClientSecret: "secret",
+		}},
+		Mapper: config.MapperConfig{MinUID: mapper.DefaultMinUID},
+	}
+}
+
+// TestEnrollRefusesForbiddenLocalUsers is the finding: oauth2-pam-enroll used to
+// write a record naming root, a service account, or a name no Unix account can
+// have, and the operator discovered it as a denied login. The mapper refuses such a
+// mapping at tier 0 regardless; this is so the refusal arrives when the name is
+// typed, before a browser round trip, and with the rule attached.
+func TestEnrollRefusesForbiddenLocalUsers(t *testing.T) {
+	forbidden := []struct{ name, why string }{
+		{"root", "root is never mappable, by UID rather than by name"},
+		{"www-data", "a denylisted service account"},
+		{"systemd-resolve", "a denylisted prefix"},
+		{"Alice", "uppercase is not a portable Unix name"},
+		{"1alice", "leading digit"},
+		{strings.Repeat("a", 33), "over 32 characters"},
+		{"al/ice", "an embedded slash"},
+		{"al\x00ice", "an embedded NUL"},
+	}
+
+	for _, tc := range forbidden {
+		t.Run(tc.why, func(t *testing.T) {
+			enrollFile := filepath.Join(t.TempDir(), "enrolled-users.yaml")
+
+			err := runEnroll(tc.name, "", nil, enrollFile, testConfig())
+			if err == nil {
+				t.Fatalf("runEnroll(%q) succeeded", tc.name)
+			}
+			if !errors.Is(err, mapper.ErrForbiddenLocalUser) {
+				t.Fatalf("error = %v, want it to wrap mapper.ErrForbiddenLocalUser", err)
+			}
+			// The message has to teach the rule and say where it comes from, or the
+			// operator is refused by a tool that is not the one denying the login and
+			// cannot tell why.
+			for _, want := range []string{"same local-account gate", "login", "mapper.min_uid", "mapper.allow_system_users"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want it to mention %q", err, want)
+				}
+			}
+			if _, err := os.Stat(enrollFile); !os.IsNotExist(err) {
+				t.Errorf("an enrollment file was created for a refused local user (stat err = %v)", err)
+			}
+		})
+	}
+}
+
+// Nothing exempts root — not allow_system_users, not a lowered floor. Same rule as
+// at login, for the same reason: a device flow has no binding to the SSH
+// connection, so root here would be the weakest path to the most privilege.
+func TestEnrollRefusesRootEvenWhenAllowedByName(t *testing.T) {
+	cfg := testConfig()
+	cfg.Mapper.AllowSystemUsers = []string{"root"}
+	cfg.Mapper.MinUID = -1
+
+	err := runEnroll("root", "", nil, filepath.Join(t.TempDir(), "enrolled-users.yaml"), cfg)
+	if !errors.Is(err, mapper.ErrForbiddenLocalUser) {
+		t.Fatalf("error = %v, want ErrForbiddenLocalUser", err)
+	}
+	if !strings.Contains(err.Error(), "UID 0") {
+		t.Errorf("error = %q, want it to name UID 0 as the reason", err)
+	}
+}
+
+// The control: a permissible name gets past the gate. It then fails on the
+// pre-existing existence check — the account does not exist on this machine — which
+// is a different error, and is how this test tells "the gate allowed it" from "the
+// gate refused it".
+func TestEnrollAcceptsAnOrdinaryLocalUser(t *testing.T) {
+	err := runEnroll("zzordinaryuser", "", nil, filepath.Join(t.TempDir(), "enrolled-users.yaml"), testConfig())
+	if err == nil {
+		t.Fatal("runEnroll reached the device flow in a unit test")
+	}
+	if errors.Is(err, mapper.ErrForbiddenLocalUser) {
+		t.Fatalf("the gate refused an ordinary Unix username: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %v, want the existing local-account existence check", err)
+	}
+}

--- a/configs/systemd/oauth2-pam-broker.service
+++ b/configs/systemd/oauth2-pam-broker.service
@@ -14,8 +14,16 @@ RestartSec=5s
 User=root
 Group=root
 
-# Runtime directory. 0750 matches the MkdirAll the broker performs itself and
-# the 0660 socket inside it: root and the group may connect, nobody else.
+# Runtime directory. 0750 matches the MkdirAll the broker performs itself and the
+# 0660 socket inside it. With Group=root above, the group is root, so this is the
+# whole access model: only root can traverse the directory and connect to the
+# socket. The PAM module qualifies because it runs inside sshd's pre-auth child.
+#
+# Do not relax either mode, and do not introduce an oauth2-pam group here, without
+# reading the note above os.Chmod in internal/ipc/server.go first: an
+# unauthenticated caller that reaches the socket can start device flows for any
+# account, and several accepted risks in this project are accepted only because
+# that caller can only be root.
 RuntimeDirectory=oauth2-pam
 RuntimeDirectoryMode=0750
 

--- a/docs/wire-protocol.md
+++ b/docs/wire-protocol.md
@@ -66,9 +66,17 @@ Every other paragraph here is in service of that sentence. In particular:
 
 - **A Unix domain socket.** No TCP, ever: the peer's identity is the point of the
   transport, and `SO_PEERCRED` is what makes per-caller rate limiting possible.
-- **Socket mode `0660`, in a directory mode `0750`.** Anything that can reach the
-  socket can start device flows. That is a bounded, audited capability, not
-  nothing.
+- **Socket mode `0660`, in a root-owned directory mode `0750`.** In this project's
+  packaging the broker runs as `root:root`, so **only root can reach the socket**,
+  and the module reaches it because it runs inside `sshd`'s pre-auth child. There
+  is no group-based access model and no service account.
+
+  This is worth stating precisely rather than leaving to packaging, because a
+  reply is only as trustworthy as the question. Anything that can reach the socket
+  can start device flows for any account and name session IDs the broker has never
+  issued — a bounded, audited capability, but not nothing. An implementation that
+  widens the socket beyond root is making a decision this specification does not
+  make for it, and it should re-examine what it is relying on before doing so.
 - **One request, one reply, one connection.** The client connects, writes exactly
   one JSON object, reads exactly one JSON object, and the connection is closed by
   the broker. There is no framing beyond that: the reply ends at EOF. There is no

--- a/docs/wire-protocol.md
+++ b/docs/wire-protocol.md
@@ -199,8 +199,40 @@ share one budget. Returns the session's current status.
 
 ### `refresh_session`
 
-Extends an authorized session using the provider's refresh token. A pending
-session is not refreshable.
+Extends the lifetime of an authorized session. **No provider round trip is
+involved** — this verb does not exchange an OAuth2 refresh token, and a broker is
+not required to hold one; it moves the broker's own `expires_at` and nothing else.
+Earlier revisions of this document said otherwise, which was wrong about every
+implementation including this one.
+
+A refresh is an extension of something still live, never a second chance at an
+authorization, so four things are refused rather than extended:
+
+- A session that is not authorized — pending, denied, expired, errored — with
+  `SESSION_NOT_ACTIVE`.
+- A session that **has already expired**, with `status: "expired"` and
+  `SESSION_EXPIRED`. The session is removed, so a second attempt gets
+  `SESSION_NOT_FOUND`. This is the same answer `check_session` gives, and the two
+  verbs are required to agree: a broker that extends an expired session lets a
+  client route around its own expiry by choosing which verb to send. This broker
+  did exactly that until v0.3.0.
+- A session **past the broker's absolute age ceiling**, also with
+  `SESSION_EXPIRED`. A ceiling is measured from when the session was created and
+  no extension moves it, so however often a client refreshes, a session cannot
+  outlive it; reaching it revokes the token at the provider. Whether there is such
+  a ceiling and how long it is are the broker's policy — `security.max_token_age`
+  here — and a client must not infer one from `expires_at`.
+- A session whose **access token is no longer usable**, also with
+  `SESSION_EXPIRED`. The session is what authorizes use of a credential, so a
+  session outliving its credential is a shell and must not be reported as
+  authorized. One consequence is worth stating because it is easy to meet by
+  accident: a broker that never extends the stored token's own lifetime will
+  refuse a second refresh once that lifetime has passed, so refresh is not
+  indefinitely repeatable even below the age ceiling.
+
+A client cannot tell those last three apart, deliberately: all of them mean this
+session is over, start a new `authenticate`. `error_message` says which, for the
+log.
 
 ### `revoke_session`
 

--- a/internal/ipc/e2e_test.go
+++ b/internal/ipc/e2e_test.go
@@ -451,6 +451,72 @@ func TestRefreshRejectsPendingSession(t *testing.T) {
 	}
 }
 
+// TestRefreshRefusesExpiredSessionOnTheWire is the wire half of the refusal
+// docs/wire-protocol.md now specifies: an expired session is refused with
+// SESSION_EXPIRED, not extended.
+//
+// The broker used to answer this exact request with `success: true`,
+// `status: "authorized"` and the mapped `user_id` — the tuple the PAM module
+// grants a login on — because RefreshSession had no expiry check and
+// `time.Until` of a past instant is simply negative. `check_session` has always
+// refused it, so the two verbs disagreed and calling this one first was a way
+// around the one that was right. Driven over the socket rather than in-process
+// because the disagreement is between two *wire verbs*, and a client picks which
+// one it sends.
+//
+// What this test pins is the *answer*, not which check produced it: a session and
+// its stored token are both given authentication.token_lifetime, so from out here
+// they run out together and either the expiry check or the token check will refuse
+// this request. Verified against the shipped code, which had neither, and it
+// returned `authorized`. The expiry check on its own is pinned by
+// TestRefreshRefusesExpiredAuthorizedSession in pkg/auth, where the session's
+// token can be given a lifetime of its own.
+func TestRefreshRefusesExpiredSessionOnTheWire(t *testing.T) {
+	h := newHarness(t, func(c *config.Config) {
+		// Short enough for a test to outlive a session, long enough that the
+		// device flow has time to finish first.
+		c.Authentication.TokenLifetime = 2 * time.Second
+		c.Authentication.RefreshThreshold = time.Second
+	})
+
+	start := h.authenticate("alice")
+	h.fake.grant()
+
+	authorized := h.waitForTerminal(start.SessionID)
+	if !authorized.Success {
+		t.Fatalf("setup: flow did not authorize: %+v", authorized)
+	}
+
+	// The reply says when the session expires, so the wait is bounded by the
+	// broker's own answer rather than by a guess about timing.
+	time.Sleep(time.Until(authorized.ExpiresAt) + 250*time.Millisecond)
+
+	resp := h.roundtrip(Request{Type: "refresh_session", SessionID: start.SessionID})
+	if resp.Success {
+		t.Errorf("refresh_session extended an expired session: status=%q user_id=%q expires_at=%s",
+			resp.Status, resp.UserID, resp.ExpiresAt)
+	}
+	if resp.Status != auth.StatusExpired {
+		t.Errorf("status = %q, want %q", resp.Status, auth.StatusExpired)
+	}
+	if resp.ErrorCode != "SESSION_EXPIRED" {
+		t.Errorf("error_code = %q, want SESSION_EXPIRED", resp.ErrorCode)
+	}
+	if resp.UserID != "" {
+		t.Errorf("user_id = %q, want empty on a refusal", resp.UserID)
+	}
+
+	// And the refusal is not a "try again later": the session is gone, so a
+	// second attempt cannot find anything to extend either.
+	again := h.roundtrip(Request{Type: "refresh_session", SessionID: start.SessionID})
+	if again.Success {
+		t.Error("a second refresh_session authorized the expired session")
+	}
+	if after := h.check(start.SessionID); after.Success {
+		t.Error("check_session authorizes a session refresh_session had just refused")
+	}
+}
+
 // TestUnknownSessionIsNotAuthorized covers a forged or stale session ID.
 func TestUnknownSessionIsNotAuthorized(t *testing.T) {
 	h := newHarness(t)

--- a/internal/ipc/ratelimit.go
+++ b/internal/ipc/ratelimit.go
@@ -51,6 +51,13 @@ type rateLimiter struct {
 	mu      sync.Mutex
 	windows map[string]*rateWindow
 	maxRPM  int
+	// maxKeys bounds how many windows may exist at once; 0 means unbounded.
+	// It matters when the key space is chosen by the caller rather than by the
+	// host, because allow() *allocates* on first sight of a key: a limiter keyed
+	// on something a client can mint at will (a session ID) will otherwise grow
+	// one entry per invented key until the next eviction tick. See
+	// maxSessionLimiterKeys.
+	maxKeys int
 }
 
 type rateWindow struct {
@@ -59,12 +66,25 @@ type rateWindow struct {
 }
 
 func newRateLimiter(maxRPM int) *rateLimiter {
+	return newBoundedRateLimiter(maxRPM, 0)
+}
+
+// newBoundedRateLimiter is newRateLimiter with a ceiling on the number of live
+// windows. At the ceiling a *new* key is refused rather than allocated; keys
+// that already have a window are unaffected, so a bucket that is already
+// established — an in-flight login's session — never starts failing because
+// somebody else filled the map.
+func newBoundedRateLimiter(maxRPM, maxKeys int) *rateLimiter {
 	if maxRPM <= 0 {
 		maxRPM = 60
+	}
+	if maxKeys < 0 {
+		maxKeys = 0
 	}
 	return &rateLimiter{
 		windows: make(map[string]*rateWindow),
 		maxRPM:  maxRPM,
+		maxKeys: maxKeys,
 	}
 }
 
@@ -74,16 +94,45 @@ func (rl *rateLimiter) allow(key string) bool {
 	defer rl.mu.Unlock()
 
 	now := time.Now()
-	w, ok := rl.windows[key]
-	if !ok || now.After(w.resetAt) {
-		rl.windows[key] = &rateWindow{count: 1, resetAt: now.Add(time.Minute)}
+	if w, ok := rl.windows[key]; ok {
+		if now.After(w.resetAt) {
+			// The window elapsed. Reuse the entry rather than reinserting it: the
+			// map does not grow, so maxKeys has nothing to say about this path.
+			w.count = 1
+			w.resetAt = now.Add(time.Minute)
+			return true
+		}
+		if w.count >= rl.maxRPM {
+			return false
+		}
+		w.count++
 		return true
 	}
-	if w.count >= rl.maxRPM {
-		return false
+
+	// A key seen for the first time is the only thing that makes the map bigger.
+	if rl.maxKeys > 0 && len(rl.windows) >= rl.maxKeys {
+		// Try to make room honestly first; a full map is usually a stale one.
+		rl.evictLocked(now)
+		if len(rl.windows) >= rl.maxKeys {
+			return false
+		}
 	}
-	w.count++
+	rl.windows[key] = &rateWindow{count: 1, resetAt: now.Add(time.Minute)}
 	return true
+}
+
+// hasLiveWindow reports whether key already has an unexpired window — that is,
+// whether allow(key) can answer without allocating.
+//
+// The broker uses it to tell an established bucket from a brand-new one, so that
+// only the act of *introducing* a key can be charged elsewhere. Racing callers
+// may both see false and both be charged, which over-charges by at most one per
+// concurrent handler and never under-charges.
+func (rl *rateLimiter) hasLiveWindow(key string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	w, ok := rl.windows[key]
+	return ok && !time.Now().After(w.resetAt)
 }
 
 // evict removes stale windows to prevent unbounded map growth.
@@ -91,7 +140,11 @@ func (rl *rateLimiter) allow(key string) bool {
 func (rl *rateLimiter) evict() {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
-	now := time.Now()
+	rl.evictLocked(time.Now())
+}
+
+// evictLocked is evict's body; the caller holds rl.mu.
+func (rl *rateLimiter) evictLocked(now time.Time) {
 	for key, w := range rl.windows {
 		if now.After(w.resetAt) {
 			delete(rl.windows, key)

--- a/internal/ipc/ratelimit_test.go
+++ b/internal/ipc/ratelimit_test.go
@@ -1,0 +1,200 @@
+package ipc
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// windowCount is the number of live map entries, read under the lock.
+func (rl *rateLimiter) windowCount() int {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	return len(rl.windows)
+}
+
+// stale ages a key's window so it counts as elapsed, instead of sleeping a minute.
+func (rl *rateLimiter) stale(t *testing.T, key string) {
+	t.Helper()
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	w, ok := rl.windows[key]
+	if !ok {
+		t.Fatalf("no window for key %q to age", key)
+	}
+	w.resetAt = time.Now().Add(-time.Second)
+}
+
+// TestRateLimiterRefusesNewKeysAtTheCap is the boundary in both directions: the
+// last key that fits is admitted, the first that does not is refused, and the
+// refusal does not leave an entry behind. Without a cap this limiter allocates a
+// window for every key it is ever shown, which is how an invented session ID
+// bought permanent broker memory.
+func TestRateLimiterRefusesNewKeysAtTheCap(t *testing.T) {
+	const keyCap = 4
+	rl := newBoundedRateLimiter(10, keyCap)
+
+	for i := 0; i < keyCap; i++ {
+		key := fmt.Sprintf("session:%d", i)
+		if !rl.allow(key) {
+			t.Fatalf("key %d of %d denied, want allowed below the cap", i+1, keyCap)
+		}
+	}
+	if got := rl.windowCount(); got != keyCap {
+		t.Fatalf("windows = %d after %d distinct keys, want %d", got, keyCap, keyCap)
+	}
+
+	if rl.allow("session:one-too-many") {
+		t.Error("a new key was admitted at the cap; the map still grows without bound")
+	}
+	if got := rl.windowCount(); got != keyCap {
+		t.Errorf("windows = %d after a refused key, want %d — the refusal allocated anyway", got, keyCap)
+	}
+}
+
+// TestRateLimiterCapDoesNotRefuseAKeyItAlreadyHolds: the cap must bound growth,
+// not start failing established buckets. A full map is not a reason to refuse an
+// in-flight login's next poll.
+func TestRateLimiterCapDoesNotRefuseAKeyItAlreadyHolds(t *testing.T) {
+	const keyCap = 2
+	rl := newBoundedRateLimiter(10, keyCap)
+
+	if !rl.allow("session:a") || !rl.allow("session:b") {
+		t.Fatal("filling the map to the cap was refused")
+	}
+	if rl.allow("session:c") {
+		t.Fatal("a third key was admitted at a cap of 2")
+	}
+
+	// session:a is established, so it keeps its budget while the map is full.
+	for i := 0; i < 5; i++ {
+		if !rl.allow("session:a") {
+			t.Fatalf("request %d for an established key was refused because the map is full", i+2)
+		}
+	}
+	// And its own per-minute limit still applies: 6 of 10 spent above.
+	for i := 0; i < 4; i++ {
+		if !rl.allow("session:a") {
+			t.Fatalf("request %d for an established key was refused below maxRPM", i+7)
+		}
+	}
+	if rl.allow("session:a") {
+		t.Error("an established key exceeded maxRPM")
+	}
+}
+
+// TestRateLimiterCapEvictsStaleWindowsBeforeRefusing: reaching the cap is usually
+// a sign the map is full of expired windows, so the honest room is taken first.
+// Otherwise the cap would wedge the limiter shut until the next eviction tick.
+func TestRateLimiterCapEvictsStaleWindowsBeforeRefusing(t *testing.T) {
+	const keyCap = 3
+	rl := newBoundedRateLimiter(10, keyCap)
+
+	for i := 0; i < keyCap; i++ {
+		if !rl.allow(fmt.Sprintf("session:%d", i)) {
+			t.Fatalf("key %d denied below the cap", i)
+		}
+	}
+	if rl.allow("session:blocked") {
+		t.Fatal("a new key was admitted with the map full of live windows")
+	}
+
+	rl.stale(t, "session:1")
+
+	if !rl.allow("session:new") {
+		t.Error("a new key was refused although a stale window could have made room")
+	}
+	if got := rl.windowCount(); got > keyCap {
+		t.Errorf("windows = %d, want at most the cap %d", got, keyCap)
+	}
+	rl.mu.Lock()
+	_, staleStillThere := rl.windows["session:1"]
+	rl.mu.Unlock()
+	if staleStillThere {
+		t.Error("the stale window survived; room was made some other way")
+	}
+}
+
+// TestRateLimiterRenewalDoesNotConsumeCapacity: an existing key whose window has
+// elapsed is renewed in place. It does not grow the map, so the cap must not
+// refuse it even when the map is full.
+func TestRateLimiterRenewalDoesNotConsumeCapacity(t *testing.T) {
+	rl := newBoundedRateLimiter(1, 1)
+
+	if !rl.allow("session:a") {
+		t.Fatal("first request denied")
+	}
+	if rl.allow("session:a") {
+		t.Fatal("second request in the same window allowed")
+	}
+
+	rl.stale(t, "session:a")
+
+	if !rl.allow("session:a") {
+		t.Error("a renewal was refused by the key cap, though it allocates nothing")
+	}
+	if got := rl.windowCount(); got != 1 {
+		t.Errorf("windows = %d after a renewal, want 1", got)
+	}
+}
+
+// TestRateLimiterWithoutACapIsUnbounded pins that the caller limiter is
+// unaffected: its key space is the host's UIDs, so a cap there could only refuse
+// a real caller.
+func TestRateLimiterWithoutACapIsUnbounded(t *testing.T) {
+	rl := newRateLimiter(10)
+	if rl.maxKeys != 0 {
+		t.Fatalf("newRateLimiter set maxKeys = %d, want 0 (unbounded)", rl.maxKeys)
+	}
+	for i := 0; i < 500; i++ {
+		if !rl.allow(fmt.Sprintf("uid:%d", i)) {
+			t.Fatalf("uncapped limiter refused key %d", i)
+		}
+	}
+	if got := rl.windowCount(); got != 500 {
+		t.Errorf("windows = %d, want 500", got)
+	}
+}
+
+func TestBoundedRateLimiterNormalisesItsArguments(t *testing.T) {
+	rl := newBoundedRateLimiter(0, -1)
+	if rl.maxRPM != 60 {
+		t.Errorf("maxRPM = %d, want the 60 default", rl.maxRPM)
+	}
+	if rl.maxKeys != 0 {
+		t.Errorf("maxKeys = %d, want 0 for a negative cap", rl.maxKeys)
+	}
+}
+
+// TestRateLimiterHasLiveWindow covers the predicate allowRequest uses to tell an
+// established bucket from one it is about to allocate. Getting this wrong in
+// either direction is a live bug: true for an unknown key means an invented
+// session ID is never charged, false for a known one means every poll is.
+func TestRateLimiterHasLiveWindow(t *testing.T) {
+	rl := newRateLimiter(10)
+
+	if rl.hasLiveWindow("session:a") {
+		t.Error("hasLiveWindow is true for a key never seen")
+	}
+	if !rl.allow("session:a") {
+		t.Fatal("first request denied")
+	}
+	if !rl.hasLiveWindow("session:a") {
+		t.Error("hasLiveWindow is false for a key that has a live window")
+	}
+
+	rl.stale(t, "session:a")
+	if rl.hasLiveWindow("session:a") {
+		t.Error("hasLiveWindow is true for an elapsed window, which allow() must reallocate")
+	}
+	// Asking must not itself allocate.
+	if got := rl.windowCount(); got != 1 {
+		t.Errorf("windows = %d, want 1: hasLiveWindow allocated", got)
+	}
+	if rl.hasLiveWindow("session:never-seen") {
+		t.Error("hasLiveWindow is true for a second unknown key")
+	}
+	if got := rl.windowCount(); got != 1 {
+		t.Errorf("windows = %d after asking about an unknown key, want 1", got)
+	}
+}

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -63,14 +63,22 @@ type Server struct {
 	// why the two cannot share a bucket.
 	rateLimiter    *rateLimiter
 	sessionLimiter *rateLimiter
+	// newSessionLimiter charges, per calling UID, the act of naming a session ID
+	// the sessionLimiter has never seen. See allowRequest and
+	// maxNewSessionsPerMinute.
+	newSessionLimiter *rateLimiter
 	// handlerSlots bounds concurrent connection handlers. See
 	// maxConcurrentHandlers.
 	handlerSlots chan struct{}
 	readTimeout  time.Duration
 	writeTimeout time.Duration
-	stopChan     chan struct{}
-	wg           sync.WaitGroup
-	stopOnce     sync.Once
+	// evictInterval is how often stale rate-limit windows are swept. A field
+	// rather than a literal so a test can watch the sweep actually happen instead
+	// of asserting that a function it calls by hand does the right thing.
+	evictInterval time.Duration
+	stopChan      chan struct{}
+	wg            sync.WaitGroup
+	stopOnce      sync.Once
 }
 
 // defaultIOTimeout applies when server.read_timeout / server.write_timeout are
@@ -93,6 +101,39 @@ const maxConcurrentHandlers = 64
 // login, so this leaves 2x headroom and only catches a client that has stopped
 // honouring the interval.
 const maxSessionRequestsPerMinute = 120
+
+// maxSessionLimiterKeys bounds how many session windows the session limiter will
+// hold at once.
+//
+// It exists because the session limiter's key space is chosen by the caller: a
+// request naming a session ID the broker has never issued still allocated a
+// window, so any client could mint windows faster than the five-minute eviction
+// sweep removed them. The better check is "refuse a session the broker does not
+// have" before the limiter sees it, but the broker exports no session-existence
+// lookup to ask with; until it does, the map has a ceiling instead.
+//
+// 8192 live windows means 8192 distinct sessions polled inside the same minute.
+// A host with that many concurrent logins in flight has run out of something
+// else first, and the ceiling costs well under a megabyte if it is ever reached.
+const maxSessionLimiterKeys = 8192
+
+// maxNewSessionsPerMinute bounds how many *previously unseen* session IDs one
+// caller may introduce per minute.
+//
+// This is the charge that makes an unknown-session flood cost the caller
+// something. It is deliberately not a charge on session requests in general:
+// every PAM caller is sshd as root, so charging each poll to the caller is the
+// host-wide login DoS that sessionKey exists to avoid. Introducing a session ID
+// is different — a legitimate login does it once, when its first check_session
+// arrives, so a real caller spends one or two units per login while a flood of
+// invented IDs spends one per request.
+//
+// 600/minute is ten new logins a second sustained from a single caller, far above
+// what a login node does and far below what the map ceiling cares about.
+const maxNewSessionsPerMinute = 600
+
+// defaultEvictInterval is how often stale rate-limit windows are swept.
+const defaultEvictInterval = 5 * time.Minute
 
 // ProtocolVersion is the wire contract this broker speaks. It is documented in
 // docs/wire-protocol.md, which is the specification both this project and its
@@ -188,14 +229,16 @@ func NewServer(socketPath string, broker *auth.Broker, cfg *config.Config) (*Ser
 	}
 
 	return &Server{
-		socketPath:     socketPath,
-		broker:         broker,
-		rateLimiter:    rl,
-		sessionLimiter: newRateLimiter(maxSessionRequestsPerMinute),
-		handlerSlots:   make(chan struct{}, maxConcurrentHandlers),
-		readTimeout:    readTimeout,
-		writeTimeout:   writeTimeout,
-		stopChan:       make(chan struct{}),
+		socketPath:        socketPath,
+		broker:            broker,
+		rateLimiter:       rl,
+		sessionLimiter:    newBoundedRateLimiter(maxSessionRequestsPerMinute, maxSessionLimiterKeys),
+		newSessionLimiter: newRateLimiter(maxNewSessionsPerMinute),
+		handlerSlots:      make(chan struct{}, maxConcurrentHandlers),
+		readTimeout:       readTimeout,
+		writeTimeout:      writeTimeout,
+		evictInterval:     defaultEvictInterval,
+		stopChan:          make(chan struct{}),
 	}, nil
 }
 
@@ -426,6 +469,14 @@ func validateRequest(req *Request) error {
 // Session operations are charged to the session instead: a poll's cost belongs
 // to one login, and bucketing them by caller made every login on the host share
 // a single budget.
+//
+// The one thing a session operation is charged to its caller for is *introducing*
+// a session ID the session limiter has not seen. That allocation is the only part
+// of a session request whose cost outlives the request — the window survives the
+// reply, and nothing here can tell an invented session ID from a real one — so it
+// is charged, and charged before the window exists. Polling an established
+// session stays free to the caller, which is what keeps concurrent logins from
+// competing for one budget.
 func (s *Server) allowRequest(conn net.Conn, req *Request) bool {
 	if req.Type == "authenticate" {
 		uid, known := peerUID(conn)
@@ -436,7 +487,17 @@ func (s *Server) allowRequest(conn net.Conn, req *Request) bool {
 		}
 		return true
 	}
-	if !s.sessionLimiter.allow(sessionKey(req.SessionID)) {
+
+	key := sessionKey(req.SessionID)
+	if !s.sessionLimiter.hasLiveWindow(key) {
+		uid, known := peerUID(conn)
+		if !s.newSessionLimiter.allow(callerKey(uid, known)) {
+			log.Warn().Uint32("uid", uid).Bool("uid_known", known).Str("type", req.Type).
+				Msg("Rate limit exceeded for new session IDs from this caller")
+			return false
+		}
+	}
+	if !s.sessionLimiter.allow(key) {
 		log.Warn().Str("type", req.Type).Msg("Rate limit exceeded for session operation")
 		return false
 	}
@@ -591,9 +652,18 @@ func formatInstructions(loginType, deviceURL, deviceCode, qrCode string) string 
 }
 
 // evictRateLimitWindows periodically cleans up stale rate-limit entries.
+//
+// Every limiter the server owns has to be swept here. This used to sweep only
+// rateLimiter, whose key space is the host's UIDs and therefore tiny; the one it
+// missed, sessionLimiter, is the one keyed on something a caller supplies, so it
+// grew one permanent entry per session ID ever named.
 func (s *Server) evictRateLimitWindows(ctx context.Context) {
 	defer s.wg.Done()
-	ticker := time.NewTicker(5 * time.Minute)
+	interval := s.evictInterval
+	if interval <= 0 {
+		interval = defaultEvictInterval
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -602,7 +672,14 @@ func (s *Server) evictRateLimitWindows(ctx context.Context) {
 		case <-s.stopChan:
 			return
 		case <-ticker.C:
-			s.rateLimiter.evict()
+			s.evictNow()
 		}
 	}
+}
+
+// evictNow sweeps every rate limiter once.
+func (s *Server) evictNow() {
+	s.rateLimiter.evict()
+	s.sessionLimiter.evict()
+	s.newSessionLimiter.evict()
 }

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -247,8 +247,8 @@ func (s *Server) Start(ctx context.Context) error {
 	if err := removeStaleSocket(s.socketPath); err != nil {
 		return err
 	}
-	// Directory needs to be accessible by the PAM module process (root-owned,
-	// group oauth2-pam). The socket itself is 0660.
+	// 0750 on a root-owned directory: only root may traverse it and reach the
+	// socket. See the socket mode below for who that leaves as the caller.
 	if err := os.MkdirAll(filepath.Dir(s.socketPath), 0750); err != nil {
 		return fmt.Errorf("create socket directory: %w", err)
 	}
@@ -259,10 +259,26 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 	s.listener = l
 
-	// 0660: readable/writable by owner and group (oauth2-pam) only.
-	// The PAM module process must run as a member of the oauth2-pam group.
-	// 0666 (world-writable) would allow any local user to send arbitrary
-	// requests to the broker.
+	// 0660 — owner and group only, never world. Combined with the 0750 directory
+	// above and the packaged unit's User=root/Group=root, that makes the broker
+	// socket reachable by root and nobody else.
+	//
+	// Root-only is the whole trust boundary, and it is worth being blunt about
+	// because a good deal rests on it: an unauthenticated caller that reaches this
+	// socket can start device flows and name session IDs, so several defects in
+	// the verbs behind it are rated low purely because only root can get here.
+	// Nothing in this process enforces that, though — it is a property of the
+	// packaging (configs/systemd/oauth2-pam-broker.service) plus the two modes
+	// set here, so a change to either widens the boundary silently. The mode is
+	// asserted in server_test.go for that reason.
+	//
+	// This is not a group-based access model, and it deliberately is not one. The
+	// module runs inside sshd's pre-auth child, which is already root, so there is
+	// no unprivileged service account that needs to reach the socket and no
+	// oauth2-pam group to add one to. Introducing a group would mean creating it
+	// in packaging and chowning both the directory and the socket, and it would
+	// hand every group member the capabilities described above. If that day comes,
+	// re-rate the findings that assume root-only first.
 	if err := os.Chmod(s.socketPath, 0660); err != nil {
 		log.Warn().Err(err).Str("socket", s.socketPath).Msg("Failed to set socket permissions")
 	}

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -154,6 +155,13 @@ func TestInvalidFieldsAreRejectedOverTheWire(t *testing.T) {
 // TestSocketPermissions: 0660 keeps arbitrary local users from talking to the
 // broker. A world-writable socket would let any user request a device flow for
 // any account.
+//
+// The directory mode is asserted alongside it because the two together are the
+// entire trust boundary. With the packaged unit running as root:root, 0750 on the
+// directory plus 0660 on the socket is what makes the broker reachable by root
+// and nobody else — and that fact is what several findings' severity rests on. It
+// is not enforced by anything at runtime, so it is enforced here: widening either
+// mode should fail a test rather than ship.
 func TestSocketPermissions(t *testing.T) {
 	h := newHarness(t)
 
@@ -163,6 +171,22 @@ func TestSocketPermissions(t *testing.T) {
 	}
 	if perm := info.Mode().Perm(); perm != 0660 {
 		t.Errorf("socket mode = %04o, want 0660", perm)
+	}
+	// Group and world must have no write bit, however the mode is spelled.
+	if perm := info.Mode().Perm(); perm&0002 != 0 {
+		t.Errorf("socket mode %04o is world-writable; any local user could drive the broker", perm)
+	}
+
+	dir, err := os.Stat(filepath.Dir(h.socket))
+	if err != nil {
+		t.Fatalf("stat socket directory: %v", err)
+	}
+	// t.TempDir() is 0700, so a harness socket lives somewhere stricter than the
+	// packaged runtime directory. Assert the property that matters in both cases —
+	// nothing for other — rather than the exact mode, which only production sets.
+	if perm := dir.Mode().Perm(); perm&0007 != 0 {
+		t.Errorf("socket directory mode = %04o, want no access for other; "+
+			"a traversable directory exposes the socket regardless of its own mode", perm)
 	}
 }
 

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -1,7 +1,9 @@
 package ipc
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -338,6 +340,208 @@ func TestRateLimiterDefaultsWhenUnset(t *testing.T) {
 		if rl.maxRPM != 60 {
 			t.Errorf("newRateLimiter(%d).maxRPM = %d, want the 60 default", maxRPM, rl.maxRPM)
 		}
+	}
+}
+
+// --- session rate-limit key space ---
+
+// newLimiterTestServer is a Server with its limiters wired as production wires
+// them, and nothing else started. Everything below exercises allowRequest and the
+// eviction sweep, neither of which touches the broker or the socket.
+func newLimiterTestServer(t *testing.T) *Server {
+	t.Helper()
+	srv, err := NewServer("/tmp/unused.sock", nil, testConfig("/tmp/unused.sock"))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv
+}
+
+// anonymousConn is a connection carrying no peer credentials, so peerUID reports
+// the caller as unidentified — the same bucket a caller the broker cannot name
+// would land in.
+func anonymousConn(t *testing.T) net.Conn {
+	t.Helper()
+	server, client := net.Pipe()
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = client.Close()
+	})
+	return server
+}
+
+func TestSessionLimiterIsBuiltWithABoundedKeySpace(t *testing.T) {
+	srv := newLimiterTestServer(t)
+
+	// The session limiter is keyed on a value the caller chooses, so its map needs
+	// a ceiling; the caller limiter is keyed on UIDs and must not have one.
+	if srv.sessionLimiter.maxKeys != maxSessionLimiterKeys {
+		t.Errorf("sessionLimiter.maxKeys = %d, want %d", srv.sessionLimiter.maxKeys, maxSessionLimiterKeys)
+	}
+	if srv.rateLimiter.maxKeys != 0 {
+		t.Errorf("rateLimiter.maxKeys = %d, want 0: capping the per-UID limiter can only refuse real callers", srv.rateLimiter.maxKeys)
+	}
+	if srv.newSessionLimiter == nil {
+		t.Fatal("no limiter charges the introduction of a new session ID")
+	}
+	if srv.newSessionLimiter.maxRPM != maxNewSessionsPerMinute {
+		t.Errorf("newSessionLimiter.maxRPM = %d, want %d", srv.newSessionLimiter.maxRPM, maxNewSessionsPerMinute)
+	}
+}
+
+// TestEvictionSweepReachesEveryLimiter is the regression test for the one-line
+// half of the bug: the sweep ran every five minutes and cleaned only
+// s.rateLimiter, so the one limiter with a caller-supplied key space —
+// sessionLimiter — kept every window it ever allocated for the life of the
+// process. It drives the real goroutine rather than calling evictNow by hand, so
+// a sweep that forgets a limiter fails here.
+func TestEvictionSweepReachesEveryLimiter(t *testing.T) {
+	srv := newLimiterTestServer(t)
+	srv.evictInterval = 5 * time.Millisecond
+
+	limiters := map[string]*rateLimiter{
+		"rateLimiter":       srv.rateLimiter,
+		"sessionLimiter":    srv.sessionLimiter,
+		"newSessionLimiter": srv.newSessionLimiter,
+	}
+	for name, rl := range limiters {
+		if !rl.allow("stale-key") {
+			t.Fatalf("%s refused its first request", name)
+		}
+		rl.stale(t, "stale-key")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	srv.wg.Add(1)
+	go srv.evictRateLimitWindows(ctx)
+	t.Cleanup(func() {
+		cancel()
+		srv.wg.Wait()
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		remaining := []string{}
+		for name, rl := range limiters {
+			if rl.windowCount() != 0 {
+				remaining = append(remaining, name)
+			}
+		}
+		if len(remaining) == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("the eviction sweep never reached %v; those windows are retained for the life of the process", remaining)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestUnknownSessionIDFloodStaysBounded is the measured reproduction from the
+// issue, in-tree: 3000 check_session requests with a distinct invented session ID
+// each left sessionLimiter holding 3000 permanent windows, with nothing charged to
+// the caller and nothing refused.
+func TestUnknownSessionIDFloodStaysBounded(t *testing.T) {
+	srv := newLimiterTestServer(t)
+	conn := anonymousConn(t)
+
+	const flood = 3000
+	refused := 0
+	for i := 0; i < flood; i++ {
+		req := &Request{Type: "check_session", SessionID: fmt.Sprintf("invented-session-%d", i)}
+		if !srv.allowRequest(conn, req) {
+			refused++
+		}
+	}
+
+	if refused == 0 {
+		t.Errorf("none of %d requests naming a session ID the broker never issued was refused; the flood costs the caller nothing", flood)
+	}
+	windows := srv.sessionLimiter.windowCount()
+	if windows > maxNewSessionsPerMinute {
+		t.Errorf("sessionLimiter holds %d windows after %d invented session IDs, want at most the caller's per-minute allowance of %d",
+			windows, flood, maxNewSessionsPerMinute)
+	}
+	if windows > maxSessionLimiterKeys {
+		t.Errorf("sessionLimiter holds %d windows, over its own ceiling of %d", windows, maxSessionLimiterKeys)
+	}
+	// The charge lands in one bucket per caller, not one per session.
+	if got := srv.newSessionLimiter.windowCount(); got != 1 {
+		t.Errorf("newSessionLimiter holds %d windows, want 1 (a single caller)", got)
+	}
+}
+
+// TestEstablishedSessionPollsSurviveAnUnknownSessionFlood is the no-regression
+// half, and the reason the caller is charged for *introducing* a session ID
+// rather than for every session request. The PAM module polls check_session for
+// up to five minutes per login and every caller is sshd as root, so a per-caller
+// charge on each poll is a host-wide login DoS (see
+// TestPollsAreBucketedPerSessionNotPerCaller). An in-flight login must keep
+// polling even while the same UID is exhausting its new-session allowance.
+func TestEstablishedSessionPollsSurviveAnUnknownSessionFlood(t *testing.T) {
+	srv := newLimiterTestServer(t)
+	conn := anonymousConn(t)
+
+	poll := func() bool {
+		return srv.allowRequest(conn, &Request{Type: "check_session", SessionID: "a-real-session"})
+	}
+
+	if !poll() {
+		t.Fatal("the first poll of a real session was refused")
+	}
+
+	// Exhaust the caller's allowance for introducing session IDs, twice over.
+	for i := 0; i < maxNewSessionsPerMinute*2; i++ {
+		srv.allowRequest(conn, &Request{Type: "check_session", SessionID: fmt.Sprintf("invented-%d", i)})
+	}
+	if srv.allowRequest(conn, &Request{Type: "check_session", SessionID: "one-more-invented"}) {
+		t.Fatal("the caller's new-session allowance was never exhausted; the flood is unbounded")
+	}
+
+	// A full minute of polling at the module's fastest permitted interval, from
+	// the session that is actually logging in. One unit is left for the revoke
+	// below, since the per-session budget is what bounds this bucket.
+	for i := 2; i < maxSessionRequestsPerMinute; i++ {
+		if !poll() {
+			t.Fatalf("poll %d of an established session was refused while another caller flooded invented IDs; this fails a legitimate login", i)
+		}
+	}
+	// refresh_session and revoke_session for that session are the same bucket.
+	if !srv.allowRequest(conn, &Request{Type: "revoke_session", SessionID: "a-real-session"}) {
+		t.Error("revoking an established session was refused")
+	}
+}
+
+// TestLegitimatePollSequenceIsNeverRateLimited runs the module's actual sequence
+// over the socket — authenticate, poll, revoke — and asserts nothing in it is
+// answered with RATE_LIMITED. The limiter changes above are only safe if this
+// holds.
+func TestLegitimatePollSequenceIsNeverRateLimited(t *testing.T) {
+	h := newHarness(t)
+
+	started := h.authenticate("alice")
+	if started.ErrorCode == ErrorCodeRateLimited {
+		t.Fatal("authenticate was rate limited")
+	}
+	if started.SessionID == "" {
+		t.Fatalf("no session was issued: %+v", started)
+	}
+
+	// 60 polls is five minutes at the module's default interval, and half the
+	// per-session budget.
+	for i := 1; i <= 60; i++ {
+		got := h.check(started.SessionID)
+		if got.ErrorCode == ErrorCodeRateLimited {
+			t.Fatalf("poll %d of a real session was answered RATE_LIMITED: %+v", i, got)
+		}
+	}
+
+	revoked := h.roundtrip(Request{Type: "revoke_session", SessionID: started.SessionID})
+	if revoked.ErrorCode == ErrorCodeRateLimited {
+		t.Fatal("revoke_session at logout was rate limited")
+	}
+	if !revoked.Success {
+		t.Errorf("revoke_session failed: %+v", revoked)
 	}
 }
 

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -350,8 +350,27 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 		return errorResponse("DEVICE_FLOW_FAILED", err.Error()), nil
 	}
 
-	// Generate QR code (best-effort)
-	qrCode, err := GenerateQRCode(deviceFlow.DeviceURL)
+	// The provider chose these two strings, and they are printed to a terminal by
+	// a root process before anyone has authenticated — so they are sanitized here,
+	// once, at the point they enter an AuthResponse.
+	//
+	// Sanitizing them in the prompt formatters is not sufficient, and it was
+	// tempting to stop there. The reply also carries device_url and device_code as
+	// their own fields, and docs/wire-protocol.md describes them as "the parts, for
+	// a client that wants to format its own prompt" — an invitation this project
+	// extends to consumers it does not control. A consumer that accepts it would
+	// receive raw provider bytes and draw them on a pre-auth tty. The contract has
+	// to be clean at the boundary, not merely clean by the time this
+	// implementation's own formatter is done with it.
+	//
+	// For github.com this is theoretical. For a configured Enterprise base_url it
+	// is not: that server picks verification_uri and user_code, so without this it
+	// picks what every host configured against it draws on screen. See #45.
+	deviceURL := SanitizePromptValue(deviceFlow.DeviceURL)
+	userCode := SanitizePromptValue(deviceFlow.UserCode)
+
+	// Generated from the sanitized URL, so the QR encodes what the text says.
+	qrCode, err := GenerateQRCode(deviceURL)
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to generate QR code")
 		qrCode = ""
@@ -401,8 +420,8 @@ func (b *Broker) Authenticate(req *AuthRequest) (*AuthResponse, error) {
 		Success:        false,
 		Status:         StatusPending,
 		SessionID:      sessionID,
-		DeviceCode:     deviceFlow.UserCode,
-		DeviceURL:      deviceFlow.DeviceURL,
+		DeviceCode:     userCode,
+		DeviceURL:      deviceURL,
 		QRCode:         qrCode,
 		ExpiresAt:      expiresAt,
 		RequiresDevice: true,

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -487,6 +487,24 @@ func terminalErrorCode(status string) string {
 }
 
 // RefreshSession extends a session if it is close to expiry.
+//
+// A refresh is an extension of something that is still live, never a second
+// chance at an authorization. Three things must hold; only the first of them used
+// to be checked:
+//
+//   - The session is authorized. A pending or terminally failed session has
+//     nothing to extend.
+//   - It has not already expired. An expired session is removed and answered
+//     SESSION_EXPIRED, exactly as CheckSession does — the two verbs used to
+//     disagree, and a client that called refresh_session first never reached the
+//     check that would have noticed, so an expired session came back authorized
+//     with an hour added to it.
+//   - It is not past the absolute security.max_token_age ceiling. That is the
+//     one bound a refresh loop cannot talk its way around; see #43.
+//
+// The extension itself goes through extendSession, a compare-and-set, because
+// the session read here is a snapshot and writing it back wholesale undid any
+// concurrent revocation.
 func (b *Broker) RefreshSession(sessionID string) (*AuthResponse, error) {
 	session := b.getSession(sessionID)
 	if session == nil {
@@ -505,16 +523,109 @@ func (b *Broker) RefreshSession(sessionID string) (*AuthResponse, error) {
 		}, nil
 	}
 
+	now := time.Now()
+
+	if session.ExpiresAt.Before(now) {
+		b.removeSession(sessionID)
+		return expiredSessionResponse(sessionID, "Session has expired"), nil
+	}
+
+	// The absolute age ceiling, checked before the "no extension needed" branch
+	// below so that neither answer can report a session the operator's policy
+	// says is over as authorized. Past it the session is revoked rather than
+	// refused-and-left: its token is destroyed at the provider, which is the
+	// whole point of having a ceiling.
+	if b.pastMaxTokenAge(session, now) {
+		log.Info().
+			Str("session_id", sessionID).
+			Str("local_user", session.LocalUser).
+			Dur("age", now.Sub(session.CreatedAt)).
+			Dur("max_token_age", b.config.Security.MaxTokenAge).
+			Msg("Session reached security.max_token_age; revoking instead of extending")
+		if err := b.RevokeSession(sessionID); err != nil {
+			log.Warn().Err(err).Str("session_id", sessionID).
+				Msg("Failed to revoke a session past max_token_age")
+		}
+		return expiredSessionResponse(sessionID,
+			"Session has reached the maximum permitted age"), nil
+	}
+
+	// The token is what the session authorizes the use of. If it no longer
+	// resolves it has been revoked or has aged out of the store, and the session
+	// is a shell that must not be reported as authorized — let alone extended.
+	//
+	// This is deliberately a second, independent check on the same fact the
+	// compare-and-set below establishes: it is the one that catches a session
+	// that was resurrected, or was never torn down properly, by some path other
+	// than the window between the read above and the write below.
+	if session.TokenID != "" {
+		if _, err := b.tokenManager.GetDecryptedAccessToken(session.TokenID); err != nil {
+			log.Warn().Err(err).Str("session_id", sessionID).
+				Msg("Authorized session has no usable token; refusing to refresh")
+			b.removeSession(sessionID)
+			return expiredSessionResponse(sessionID, "Session credentials are no longer valid"), nil
+		}
+	}
+
 	if time.Until(session.ExpiresAt) > b.config.Authentication.RefreshThreshold {
 		return b.successResponse(session), nil
 	}
 
-	// Extend the session lifetime
-	session.ExpiresAt = time.Now().Add(b.config.Authentication.TokenLifetime)
-	session.LastAccessed = time.Now()
-	b.setSession(session)
+	// Extend the session lifetime, but only if it is still the same authorized
+	// session that was read above.
+	expiresAt := now.Add(b.config.Authentication.TokenLifetime)
+	if !b.extendSession(sessionID, session.CreatedAt, func(s *Session) {
+		s.ExpiresAt = expiresAt
+		s.LastAccessed = now
+	}) {
+		// Revoked, expired, or replaced while this call was deciding. Report what
+		// is true now rather than the snapshot's view of it. The error codes are
+		// the same two a caller would have got a moment earlier; the messages name
+		// the window, because "it was there when I read it" is the only distinction
+		// worth having in a log — and it is what a test can count to know the
+		// window was really exercised.
+		if live := b.getSession(sessionID); live != nil {
+			return &AuthResponse{
+				Success:      false,
+				Status:       live.Status,
+				SessionID:    sessionID,
+				ErrorCode:    "SESSION_NOT_ACTIVE",
+				ErrorMessage: msgDeactivatedWhileRefreshing,
+			}, nil
+		}
+		return errorResponse("SESSION_NOT_FOUND", msgRevokedWhileRefreshing), nil
+	}
+
+	// session is this call's private snapshot and never goes back into the map;
+	// bringing it up to date is only so the reply states the expiry that was
+	// actually stored.
+	session.ExpiresAt = expiresAt
+	session.LastAccessed = now
 
 	return b.successResponse(session), nil
+}
+
+// The two messages RefreshSession uses when its compare-and-set refuses, named
+// so the race regression test can count the interleavings it claims to exercise
+// instead of assuming they happened. error_message is diagnostic by contract —
+// see docs/wire-protocol.md — so no client decides anything on these.
+const (
+	msgRevokedWhileRefreshing     = "Session was revoked while it was being refreshed"
+	msgDeactivatedWhileRefreshing = "Session stopped being authorized while it was being refreshed"
+)
+
+// expiredSessionResponse is the reply for a session that has run out of time,
+// whether by its own expiry or by the absolute age ceiling. Both are
+// SESSION_EXPIRED: from a client's point of view the session ran out of time,
+// and the reason is the broker's log's business.
+func expiredSessionResponse(sessionID, message string) *AuthResponse {
+	return &AuthResponse{
+		Success:      false,
+		Status:       StatusExpired,
+		SessionID:    sessionID,
+		ErrorCode:    "SESSION_EXPIRED",
+		ErrorMessage: message,
+	}
 }
 
 // RevokeSession removes a session and revokes its stored access token.
@@ -889,6 +1000,47 @@ func (b *Broker) activateSession(sessionID string, createdAt time.Time, mutate f
 	return true
 }
 
+// extendSession pushes an authorized session's lifetime out under a single lock,
+// applying mutate to the stored entry. It returns false — changing nothing — if
+// the session is gone, is no longer an authorized one, or is not the same
+// session the caller read: as in activateSession, CreatedAt distinguishes a
+// session that was removed and had its ID reused from the one being refreshed.
+//
+// It exists for the same reason activateSession does. RefreshSession decides on a
+// snapshot, and writing that snapshot back with setSession was a lost update: a
+// RevokeSession or a cleanup pass that deleted the session in between was
+// silently undone, and the re-inserted entry named a TokenID that had already
+// been destroyed at the provider. The result was an authorized session with no
+// token, no poller, and a brand-new hour to live, which check_session answered
+// with success. Reproduced on 1 of 200 unassisted attempts before this.
+func (b *Broker) extendSession(sessionID string, createdAt time.Time, mutate func(*Session)) bool {
+	b.sessionMutex.Lock()
+	defer b.sessionMutex.Unlock()
+
+	s, ok := b.sessions[sessionID]
+	if !ok || !s.IsActive || s.Status != StatusAuthorized || !s.CreatedAt.Equal(createdAt) {
+		return false
+	}
+	mutate(s)
+	return true
+}
+
+// pastMaxTokenAge reports whether a session has outlived
+// security.max_token_age, the absolute ceiling on how old a session may become
+// however many times it is refreshed. Measured from CreatedAt, which no
+// extension moves.
+//
+// 0 means unset, matching the config-consistency check in pkg/config that was
+// for a while the only place this value was read at all. The comparison is
+// strictly greater-than, so a session exactly at the ceiling is still inside it.
+func (b *Broker) pastMaxTokenAge(s *Session, now time.Time) bool {
+	max := b.config.Security.MaxTokenAge
+	if max <= 0 {
+		return false
+	}
+	return now.Sub(s.CreatedAt) > max
+}
+
 // baseContext is the parent for per-session polling contexts. Start records the
 // broker's context; a broker used without Start (some tests, and any future
 // caller that only wants Authenticate) still needs a usable parent.
@@ -1159,26 +1311,38 @@ func (b *Broker) sessionCleanup(ctx context.Context) {
 		case <-b.stopChan:
 			return
 		case <-ticker.C:
-			now := time.Now()
-			var expired []string
-
-			b.sessionMutex.RLock()
-			for id, s := range b.sessions {
-				if s.ExpiresAt.Before(now) {
-					expired = append(expired, id)
-				}
-			}
-			b.sessionMutex.RUnlock()
-
-			for _, id := range expired {
-				if err := b.RevokeSession(id); err != nil {
-					log.Warn().Err(err).Str("session_id", id).Msg("Failed to revoke expired session during cleanup")
-				}
-			}
-
-			if len(expired) > 0 {
-				log.Info().Int("count", len(expired)).Msg("Cleaned up expired sessions")
-			}
+			b.cleanupExpiredSessions(time.Now())
 		}
 	}
+}
+
+// cleanupExpiredSessions revokes every session that has run out of time and
+// returns how many it revoked. A session is out of time either because its own
+// ExpiresAt has passed or because it has outlived security.max_token_age — the
+// ceiling has to be swept for as well as checked on refresh, or a session nobody
+// ever calls refresh_session on simply lives to its extended expiry.
+//
+// Split out of sessionCleanup's ticker loop, and takes `now` as an argument, so
+// a test can drive one sweep instead of waiting five minutes for the tick.
+func (b *Broker) cleanupExpiredSessions(now time.Time) int {
+	var expired []string
+
+	b.sessionMutex.RLock()
+	for id, s := range b.sessions {
+		if s.ExpiresAt.Before(now) || b.pastMaxTokenAge(s, now) {
+			expired = append(expired, id)
+		}
+	}
+	b.sessionMutex.RUnlock()
+
+	for _, id := range expired {
+		if err := b.RevokeSession(id); err != nil {
+			log.Warn().Err(err).Str("session_id", id).Msg("Failed to revoke expired session during cleanup")
+		}
+	}
+
+	if len(expired) > 0 {
+		log.Info().Int("count", len(expired)).Msg("Cleaned up expired sessions")
+	}
+	return len(expired)
 }

--- a/pkg/auth/qr_code.go
+++ b/pkg/auth/qr_code.go
@@ -23,9 +23,20 @@ func GenerateQRCode(url string) (string, error) {
 // So none of these may promise that authorization completes on its own. It
 // does not — a user who approves on their phone and waits, having been told
 // waiting is all that is required, sits there until the login times out.
+//
+// They are also printed by the module's conversation function, as root, before
+// authentication completes, so every formatter below sanitizes its
+// provider-supplied arguments before writing them into the template. Doing it
+// here rather than at the call site in internal/ipc covers all three prompts
+// however they are reached, and cannot be forgotten by a fourth. See
+// sanitize.go for the policy and why it differs between a value and a block.
 
 // FormatDeviceInstructions formats the device flow prompt for SSH / generic terminal.
 func FormatDeviceInstructions(deviceURL, userCode, qrCode string) string {
+	deviceURL = SanitizePromptValue(deviceURL)
+	userCode = SanitizePromptValue(userCode)
+	qrCode = SanitizePromptBlock(qrCode)
+
 	var b strings.Builder
 
 	b.WriteString("GitHub Authentication Required\n")
@@ -53,6 +64,10 @@ func FormatDeviceInstructions(deviceURL, userCode, qrCode string) string {
 
 // FormatConsoleInstructions formats the device flow prompt for a console login.
 func FormatConsoleInstructions(deviceURL, userCode, qrCode string) string {
+	deviceURL = SanitizePromptValue(deviceURL)
+	userCode = SanitizePromptValue(userCode)
+	qrCode = SanitizePromptBlock(qrCode)
+
 	var b strings.Builder
 
 	b.WriteString("\nGitHub Authentication Required\n\n")
@@ -74,6 +89,11 @@ func FormatConsoleInstructions(deviceURL, userCode, qrCode string) string {
 
 // FormatGUIInstructions formats the device flow prompt for a GUI login manager.
 func FormatGUIInstructions(deviceURL, userCode, qrCode string) string {
+	// qrCode is deliberately not used: a GUI login dialog renders plain text and
+	// ASCII art would be unreadable there. Nothing to sanitize as a result.
+	deviceURL = SanitizePromptValue(deviceURL)
+	userCode = SanitizePromptValue(userCode)
+
 	var b strings.Builder
 
 	b.WriteString("Authentication Required\n\n")

--- a/pkg/auth/qr_code_test.go
+++ b/pkg/auth/qr_code_test.go
@@ -86,6 +86,104 @@ func TestQRCodeIsIncludedWhenSupplied(t *testing.T) {
 	}
 }
 
+// hostileDeviceURL and hostileUserCode are what a compromised or hostile
+// provider can return. For github.com this cannot happen, but a configured
+// GitHub Enterprise base_url chooses both verification_uri and user_code, and
+// the instructions built from them are printed to the terminal by the PAM
+// conversation function, as root, before authentication completes. Left
+// verbatim, that is an arbitrary-draw primitive on a pre-auth terminal.
+const (
+	// Clear the screen, home the cursor, and draw a convincing password prompt
+	// over the top of the real one.
+	hostileDeviceURL = "https://ghes.corp.example/login/device" +
+		"\x1b[2J\x1b[H\x1b[1;1fPassword: \x1b[8m"
+	// Colour, a bare ESC, a CR to overwrite the line, a NUL, a DEL, a C1 CSI,
+	// and a newline to break out of the template's line.
+	hostileUserCode = "WDJB\x1b[31m\x1b\rMJHT\x00\x7f\u009b31m\x9b7m\nsudo password: "
+)
+
+// TestInstructionsSanitizeProviderStrings is the regression test for the
+// finding. It asserts the property rather than an expected string, so that it
+// keeps working when the template wording changes: whatever the formatters
+// emit, it must carry no control character other than the newlines the trusted
+// template itself writes.
+func TestInstructionsSanitizeProviderStrings(t *testing.T) {
+	qr, err := GenerateQRCode(testDeviceURL)
+	if err != nil {
+		t.Fatalf("GenerateQRCode: %v", err)
+	}
+
+	for name, format := range allFormatters() {
+		t.Run(name, func(t *testing.T) {
+			for _, qrCode := range []string{"", qr, "block\x1b[2J\n"} {
+				out := format(hostileDeviceURL, hostileUserCode, qrCode)
+				// Newline is allowed: the template is multi-line and trusted.
+				assertNoDisallowedRunes(t, true, out)
+			}
+		})
+	}
+}
+
+// TestInstructionsKeepProviderValuesOnTheirOwnLine is the reason the value
+// policy is stricter than the template's. A provider that can emit a newline
+// can put text at the start of a line, which is what makes a fake prompt
+// convincing; a value confined to the middle of a template line cannot.
+func TestInstructionsKeepProviderValuesOnTheirOwnLine(t *testing.T) {
+	for name, format := range allFormatters() {
+		t.Run(name, func(t *testing.T) {
+			out := format(hostileDeviceURL, hostileUserCode, "")
+			for i, line := range strings.Split(out, "\n") {
+				for _, injected := range []string{"Password:", "sudo password:"} {
+					if strings.HasPrefix(strings.TrimSpace(line), injected) {
+						t.Errorf("line %d begins with the injected %q, so the provider started a line of its own:\n%s",
+							i+1, injected, out)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestInstructionsSayWhenTheyDroppedSomething: a sanitizer that quietly mangles
+// a URL leaves the operator debugging a broken login with no clue that the
+// provider sent something it should not have.
+func TestInstructionsSayWhenTheyDroppedSomething(t *testing.T) {
+	for name, format := range allFormatters() {
+		t.Run(name, func(t *testing.T) {
+			out := format(hostileDeviceURL, hostileUserCode, "")
+			if !strings.Contains(out, "control character") {
+				t.Errorf("the instructions do not mention that anything was removed:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestFormattingLeavesARealQRCodeIntact: the ASCII QR code is block-drawing
+// runes and newlines by construction, and sanitizing it as if it were a
+// single-line value would collapse it into one unreadable line for everybody.
+func TestFormattingLeavesARealQRCodeIntact(t *testing.T) {
+	qr, err := GenerateQRCode(testDeviceURL)
+	if err != nil {
+		t.Fatalf("GenerateQRCode: %v", err)
+	}
+
+	for name, format := range allFormatters() {
+		if name == "gui" {
+			continue // deliberately omits the QR code; see the test above
+		}
+		t.Run(name, func(t *testing.T) {
+			out := format(testDeviceURL, testUserCode, qr)
+			if !strings.Contains(out, qr) {
+				t.Errorf("the QR code did not survive formatting byte-for-byte.\nwanted (%d lines):\n%s\ngot:\n%s",
+					strings.Count(qr, "\n"), qr, out)
+			}
+			if strings.Contains(out, "control character") {
+				t.Errorf("a clean QR code was reported as needing sanitizing:\n%s", out)
+			}
+		})
+	}
+}
+
 // TestInstructionsFitTheModulePromptBuffer: the module copies the instructions
 // into a fixed 16 KB field (MAX_RESPONSE_SIZE in cgo_bridge.h) and strncpy
 // silently truncates anything longer — which would cut the code off the end of

--- a/pkg/auth/refresh_test.go
+++ b/pkg/auth/refresh_test.go
@@ -1,0 +1,479 @@
+package auth
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Regression tests for the two defects in the session-extension path (#41, #43),
+// both of which ended with the broker answering "authorized" for a session that
+// should have been over: an expired one that refresh extended instead of
+// refusing, a revoked one that refresh put back, and a session refreshed
+// indefinitely past security.max_token_age.
+
+// authorizedSession installs a live authorized session with a real token in the
+// token manager, which is what makes "the token was destroyed" observable. The
+// token's own expiry is deliberately far out, so a refusal is never attributable
+// to the token having aged out on its own.
+func authorizedSession(t *testing.T, b *Broker, id string, createdAt, expiresAt time.Time) *Session {
+	t.Helper()
+
+	tokenID, err := b.tokenManager.StoreToken(id, "alice", "access-token-"+id, "",
+		time.Now().Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+
+	s := &Session{
+		ID:                 id,
+		TokenID:            tokenID,
+		LocalUser:          "alice",
+		RequestedLocalUser: "alice",
+		ProviderLogin:      "alice",
+		Provider:           "acme",
+		CreatedAt:          createdAt,
+		ExpiresAt:          expiresAt,
+		LastAccessed:       createdAt,
+		Status:             StatusAuthorized,
+		IsActive:           true,
+	}
+	b.setSession(s)
+	return s
+}
+
+// tokenLives reports whether a token is still in the manager. A session that
+// authorizes a login while this is false is the resurrection symptom: the token
+// has been revoked at the provider and the session outlived it.
+func tokenLives(b *Broker, tokenID string) bool {
+	b.tokenManager.tokenStore.mutex.RLock()
+	defer b.tokenManager.tokenStore.mutex.RUnlock()
+	_, ok := b.tokenManager.tokenStore.tokens[tokenID]
+	return ok
+}
+
+// TestRefreshRefusesExpiredAuthorizedSession is the deterministic half of #41.
+//
+// RefreshSession had no expiry check at all: time.Until on a past timestamp is
+// negative, so an expired session fell straight through to the extend branch and
+// came back authorized with a fresh hour on it. CheckSession has always removed
+// such a session and answered SESSION_EXPIRED, so the two verbs disagreed about
+// what an expired session is, and a client that called refresh_session first
+// never reached the one that was right.
+func TestRefreshRefusesExpiredAuthorizedSession(t *testing.T) {
+	b := startBroker(t, brokerConfig(t), newFakeProvider("acme"))
+
+	now := time.Now()
+	s := authorizedSession(t, b, "expired-authorized", now.Add(-2*time.Hour), now.Add(-time.Minute))
+
+	resp, err := b.RefreshSession(s.ID)
+	if err != nil {
+		t.Fatalf("RefreshSession: %v", err)
+	}
+	if resp.Success {
+		t.Errorf("refresh extended an expired session: success=true user_id=%q expires_at=%s",
+			resp.UserID, resp.ExpiresAt)
+	}
+	if resp.Status != StatusExpired {
+		t.Errorf("status = %q, want %q — refresh_session must agree with check_session", resp.Status, StatusExpired)
+	}
+	if resp.ErrorCode != "SESSION_EXPIRED" {
+		t.Errorf("error_code = %q, want SESSION_EXPIRED", resp.ErrorCode)
+	}
+	if resp.UserID != "" {
+		t.Errorf("user_id = %q, want empty on a refusal", resp.UserID)
+	}
+
+	// Removed, not merely refused: the next check_session must not find it either.
+	if live := b.getSession(s.ID); live != nil {
+		t.Errorf("expired session is still in the map with expires_at=%s", live.ExpiresAt)
+	}
+	check, err := b.CheckSession(s.ID)
+	if err != nil {
+		t.Fatalf("CheckSession: %v", err)
+	}
+	if check.Success {
+		t.Error("check_session authorized a session refresh had just refused")
+	}
+}
+
+// TestRefreshExtendsALiveSession is the companion that stops the test above from
+// passing for the wrong reason. Without it, a RefreshSession that refused
+// everything would look correct.
+func TestRefreshExtendsALiveSession(t *testing.T) {
+	b := startBroker(t, brokerConfig(t), newFakeProvider("acme"))
+
+	now := time.Now()
+	// Inside authentication.refresh_threshold (one minute in brokerConfig), so
+	// the call takes the extension branch rather than returning early.
+	s := authorizedSession(t, b, "live", now, now.Add(30*time.Second))
+	before := s.ExpiresAt
+
+	resp, err := b.RefreshSession(s.ID)
+	if err != nil {
+		t.Fatalf("RefreshSession: %v", err)
+	}
+	if !resp.Success || resp.Status != StatusAuthorized {
+		t.Fatalf("success = %v, status = %q (%s); want a live session to refresh",
+			resp.Success, resp.Status, resp.ErrorCode)
+	}
+	if !resp.ExpiresAt.After(before) {
+		t.Errorf("expires_at = %s, want later than %s — nothing was extended", resp.ExpiresAt, before)
+	}
+
+	live := b.getSession(s.ID)
+	if live == nil {
+		t.Fatal("refresh removed the session it extended")
+	}
+	if !live.ExpiresAt.Equal(resp.ExpiresAt) {
+		t.Errorf("stored expires_at = %s but the reply said %s; the extension was not applied to the stored entry",
+			live.ExpiresAt, resp.ExpiresAt)
+	}
+}
+
+// TestExtendSessionRefusesUnlessStillTheSameAuthorizedSession exercises the
+// compare-and-set arm by arm, the way
+// TestActivateSessionRefusesUnlessStillTheSamePendingSession does for
+// activation. Each refusal here is a way a deleted or demoted session could
+// otherwise be written back into the map by a refresh that read it a moment
+// earlier.
+func TestExtendSessionRefusesUnlessStillTheSameAuthorizedSession(t *testing.T) {
+	b := startBroker(t, brokerConfig(t), newFakeProvider("acme"))
+
+	created := time.Now()
+	newAuthorized := func(id string) *Session {
+		return authorizedSession(t, b, id, created, created.Add(time.Minute))
+	}
+	extended := func(s *Session) bool {
+		return b.extendSession(s.ID, created, func(s *Session) {
+			s.ExpiresAt = created.Add(time.Hour)
+		})
+	}
+
+	t.Run("still the same authorized session", func(t *testing.T) {
+		s := newAuthorized("ok")
+		if !extended(s) {
+			t.Fatal("extendSession refused an unchanged authorized session")
+		}
+		if got := b.getSession("ok"); !got.ExpiresAt.Equal(created.Add(time.Hour)) {
+			t.Errorf("expires_at = %s, want the mutation applied to the stored entry", got.ExpiresAt)
+		}
+	})
+
+	t.Run("gone", func(t *testing.T) {
+		if b.extendSession("missing", created, func(*Session) {}) {
+			t.Error("extendSession extended a session that no longer exists; a revoked session would be resurrected")
+		}
+	})
+
+	t.Run("deactivated", func(t *testing.T) {
+		s := newAuthorized("inactive")
+		s.IsActive = false
+		if extended(s) {
+			t.Error("extendSession extended an inactive session")
+		}
+	})
+
+	t.Run("no longer authorized", func(t *testing.T) {
+		s := newAuthorized("failed")
+		s.Status = StatusExpired
+		if extended(s) {
+			t.Error("extendSession extended a session that had gone terminal")
+		}
+	})
+
+	t.Run("id reused by a newer session", func(t *testing.T) {
+		s := newAuthorized("reused")
+		if b.extendSession(s.ID, created.Add(-time.Second), func(*Session) {}) {
+			t.Error("extendSession accepted a stale CreatedAt; a refresh could extend a different session")
+		}
+	})
+}
+
+// TestRefreshDoesNotResurrectRevokedSession is the race half of #41.
+//
+// RefreshSession read a snapshot and wrote it back wholesale, so a
+// RevokeSession that deleted the session in between was silently undone: the
+// re-inserted entry named a TokenID that had already been destroyed at the
+// provider, had no poller, and had a brand-new hour to live — and check_session
+// answered it with success and user_id.
+//
+// This is a logic bug, not a data race: every access is properly locked and -race
+// sees nothing. So the proof has to be the outcome, and the outcome is only
+// visible when the two calls interleave inside a window a few instructions wide.
+// There is no deterministic way to force it from out here — the window is between
+// two lock acquisitions inside RefreshSession, and the only hook that would close
+// it deterministically would be test scaffolding in the broker itself. So this is
+// a bounded loop, and the two things that make it meaningful rather than
+// decorative are:
+//
+//   - Many pairs race at once, not one at a time, on more than one P. One pair
+//     per round is what the reviewer did by hand and it landed on 1 attempt in
+//     200; measured against the unfixed code, 2000 sequential pairs found the
+//     defect 0 to 1 times and missed it entirely on 5 of 8 runs, and GOMAXPROCS=1
+//     missed it on 10 of 10 however many pairs raced. Racing pairsPerRound at a
+//     time with GOMAXPROCS pinned above 1 gives the scheduler enough runnable
+//     goroutines to preempt inside the window: the unfixed code then fails in the
+//     first round or two of every run.
+//   - The loop counts how many refreshes actually found the session deleted
+//     underneath them, and fails if that never happened. Both call orders
+//     occurring is not enough — measured at GOMAXPROCS=1, both orders occurred in
+//     every run while the window itself was never hit once, which is precisely the
+//     shape of a test that cannot fail.
+//
+// The deterministic proof of the same guarantee, arm by arm, is
+// TestExtendSessionRefusesUnlessStillTheSameAuthorizedSession above; this test is
+// what says the guarantee is wired into the verb.
+func TestRefreshDoesNotResurrectRevokedSession(t *testing.T) {
+	// Raised, never lowered, and restored afterwards: without real parallelism
+	// this test still passes and proves nothing.
+	if runtime.GOMAXPROCS(0) < 4 {
+		prev := runtime.GOMAXPROCS(4)
+		t.Cleanup(func() { runtime.GOMAXPROCS(prev) })
+	}
+
+	b := startBroker(t, brokerConfig(t), newFakeProvider("acme"))
+
+	const (
+		pairsPerRound = 32
+		rounds        = 64
+	)
+	var sawLiveRead, sawAlreadyGone, sawDeletedUnderneath int
+
+	for round := 0; round < rounds; round++ {
+		ids := make([]string, pairsPerRound)
+		tokens := make([]string, pairsPerRound)
+		replies := make([]*AuthResponse, pairsPerRound)
+
+		now := time.Now()
+		for i := range ids {
+			ids[i] = fmt.Sprintf("race-%d-%d", round, i)
+			// Inside refresh_threshold so the refresh reaches the write, which is
+			// where the window is.
+			s := authorizedSession(t, b, ids[i], now, now.Add(30*time.Second))
+			tokens[i] = s.TokenID
+		}
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for i := range ids {
+			i, id := i, ids[i]
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				<-start
+				resp, err := b.RefreshSession(id)
+				if err != nil {
+					panic(fmt.Sprintf("RefreshSession: %v", err))
+				}
+				replies[i] = resp
+			}()
+			go func() {
+				defer wg.Done()
+				<-start
+				_ = b.RevokeSession(id)
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		for i, id := range ids {
+			// Whichever order the two landed in, the invariant is the same: nothing
+			// may be left authorized once its token has been destroyed.
+			live := b.getSession(id)
+			if live != nil && live.IsActive && live.Status == StatusAuthorized && !tokenLives(b, tokens[i]) {
+				t.Fatalf("round %d pair %d: revoked session is authorized again (user_id=%q token_destroyed=true expires_at=%s); refresh resurrected it",
+					round+1, i, live.LocalUser, live.ExpiresAt)
+			}
+			if live != nil {
+				t.Fatalf("round %d pair %d: session survived revocation (status=%q active=%v)",
+					round+1, i, live.Status, live.IsActive)
+			}
+			if check, err := b.CheckSession(id); err != nil {
+				t.Fatalf("CheckSession: %v", err)
+			} else if check.Success {
+				t.Fatalf("round %d pair %d: check_session authorizes a revoked session (user_id=%q)",
+					round+1, i, check.UserID)
+			}
+
+			// Which answer the refresh gave says where in the call the revocation
+			// landed, and that is how this test knows what it exercised.
+			switch replies[i].ErrorMessage {
+			case msgRevokedWhileRefreshing, msgDeactivatedWhileRefreshing:
+				// The compare-and-set refused: the session was deleted after this
+				// refresh had read and vetted it. This is the window, and in the
+				// unfixed code these are the pairs that resurrected a session.
+				sawDeletedUnderneath++
+				sawLiveRead++
+			case "Session not found":
+				sawAlreadyGone++
+			default:
+				sawLiveRead++
+			}
+		}
+	}
+
+	total := pairsPerRound * rounds
+	t.Logf("%d racing pairs: %d refreshes read a live session (%d of them had it deleted underneath), %d found it already revoked",
+		total, sawLiveRead, sawDeletedUnderneath, sawAlreadyGone)
+	if sawLiveRead == 0 || sawAlreadyGone == 0 {
+		t.Errorf("refresh and revoke never interleaved across %d pairs (%d read a live session, %d found it gone); "+
+			"this test cannot fail as written and must be fixed rather than trusted",
+			total, sawLiveRead, sawAlreadyGone)
+	}
+	if sawDeletedUnderneath == 0 {
+		t.Errorf("not one of %d pairs had its session deleted between the read and the write; "+
+			"that window is the whole defect, so this run tested nothing and the loop must be "+
+			"made to race rather than trusted", total)
+	}
+}
+
+// TestMaxTokenAgeIsAnAbsoluteCeilingOnRefresh is #43: security.max_token_age was
+// parsed, defaulted, documented, and compared against token_lifetime at startup —
+// and never once compared against a session's age. Nothing bounded a refresh
+// loop, so a session could be extended indefinitely past the ceiling the
+// operator configured. Measured before the fix with max_token_age at 2s: fifty
+// consecutive refreshes all succeeded.
+//
+// Both directions are asserted so the comparison cannot be silently inverted,
+// and the session past the ceiling is given an expiry far in the future so that
+// nothing but its age can explain the refusal.
+func TestMaxTokenAgeIsAnAbsoluteCeilingOnRefresh(t *testing.T) {
+	const ceiling = 2 * time.Hour
+
+	cfg := brokerConfig(t)
+	cfg.Security.MaxTokenAge = ceiling
+	b := startBroker(t, cfg, newFakeProvider("acme"))
+
+	t.Run("inside the ceiling extends", func(t *testing.T) {
+		now := time.Now()
+		s := authorizedSession(t, b, "young", now.Add(-ceiling+time.Minute), now.Add(30*time.Second))
+		// s is the stored entry, and the extension mutates it in place, so the
+		// expiry to compare against has to be copied before the call.
+		before := s.ExpiresAt
+
+		resp, err := b.RefreshSession(s.ID)
+		if err != nil {
+			t.Fatalf("RefreshSession: %v", err)
+		}
+		if !resp.Success {
+			t.Fatalf("status = %q (%s); a session inside max_token_age must still refresh, or the check is inverted",
+				resp.Status, resp.ErrorCode)
+		}
+		if !resp.ExpiresAt.After(before) {
+			t.Errorf("expires_at = %s, want later than %s", resp.ExpiresAt, before)
+		}
+	})
+
+	t.Run("past the ceiling is refused however long it has left", func(t *testing.T) {
+		now := time.Now()
+		// Expiry half an hour away: this session is nowhere near expiring, and is
+		// not even inside refresh_threshold, so only its age can refuse it.
+		s := authorizedSession(t, b, "old", now.Add(-ceiling-time.Minute), now.Add(30*time.Minute))
+		tokenID := s.TokenID
+
+		resp, err := b.RefreshSession(s.ID)
+		if err != nil {
+			t.Fatalf("RefreshSession: %v", err)
+		}
+		if resp.Success {
+			t.Fatalf("a session %s old was refreshed under a %s ceiling: success=true user_id=%q expires_at=%s",
+				ceiling+time.Minute, ceiling, resp.UserID, resp.ExpiresAt)
+		}
+		if resp.Status != StatusExpired {
+			t.Errorf("status = %q, want %q", resp.Status, StatusExpired)
+		}
+		if resp.ErrorCode != "SESSION_EXPIRED" {
+			t.Errorf("error_code = %q, want SESSION_EXPIRED", resp.ErrorCode)
+		}
+
+		// Revoked, not merely refused: the ceiling is a security control, so the
+		// token must be gone too.
+		if live := b.getSession(s.ID); live != nil {
+			t.Errorf("session past max_token_age is still in the map (status=%q expires_at=%s)",
+				live.Status, live.ExpiresAt)
+		}
+		if tokenLives(b, tokenID) {
+			t.Error("session past max_token_age was refused but its token is still in the store")
+		}
+	})
+
+	t.Run("exactly at the ceiling is still inside it", func(t *testing.T) {
+		now := time.Now()
+		// CreatedAt is a hair under the ceiling away, which is the closest a test
+		// can get to the boundary without the clock deciding the outcome. Pinned
+		// so that "older than" cannot quietly become "at least as old as".
+		s := authorizedSession(t, b, "boundary", now.Add(-ceiling).Add(2*time.Second), now.Add(30*time.Second))
+
+		if b.pastMaxTokenAge(s, now) {
+			t.Errorf("a session %s old is past a %s ceiling", ceiling-2*time.Second, ceiling)
+		}
+		if resp, err := b.RefreshSession(s.ID); err != nil {
+			t.Fatalf("RefreshSession: %v", err)
+		} else if !resp.Success {
+			t.Errorf("status = %q (%s), want the boundary session to refresh", resp.Status, resp.ErrorCode)
+		}
+	})
+
+	t.Run("unset means no ceiling", func(t *testing.T) {
+		unset := brokerConfig(t)
+		unset.Security.MaxTokenAge = 0
+		other := startBroker(t, unset, newFakeProvider("acme"))
+
+		now := time.Now()
+		s := authorizedSession(t, other, "ancient", now.Add(-30*24*time.Hour), now.Add(30*time.Second))
+
+		if other.pastMaxTokenAge(s, now) {
+			t.Error("max_token_age = 0 is unset and must not bound anything")
+		}
+		if resp, err := other.RefreshSession(s.ID); err != nil {
+			t.Fatalf("RefreshSession: %v", err)
+		} else if !resp.Success {
+			t.Errorf("status = %q (%s); an unset ceiling refused a refresh", resp.Status, resp.ErrorCode)
+		}
+	})
+}
+
+// TestSessionCleanupRevokesSessionsPastMaxTokenAge covers the other half of #43.
+// Enforcing the ceiling only in RefreshSession would leave it unenforced for
+// every session nobody calls refresh_session on — which today is all of them, as
+// no in-tree client sends that verb.
+func TestSessionCleanupRevokesSessionsPastMaxTokenAge(t *testing.T) {
+	const ceiling = 2 * time.Hour
+
+	cfg := brokerConfig(t)
+	cfg.Security.MaxTokenAge = ceiling
+	fake := newFakeProvider("acme")
+	b := startBroker(t, cfg, fake)
+
+	now := time.Now()
+	// Both are well inside their own expiry, so ExpiresAt cannot explain either
+	// outcome; the only difference between them is age.
+	old := authorizedSession(t, b, "old", now.Add(-ceiling-time.Minute), now.Add(30*time.Minute))
+	young := authorizedSession(t, b, "young", now.Add(-time.Minute), now.Add(30*time.Minute))
+
+	if n := b.cleanupExpiredSessions(now); n != 1 {
+		t.Errorf("cleanup revoked %d sessions, want exactly 1 (the one past max_token_age)", n)
+	}
+
+	if live := b.getSession(old.ID); live != nil {
+		t.Errorf("a session %s old survived cleanup under a %s ceiling (expires_at=%s)",
+			ceiling+time.Minute, ceiling, live.ExpiresAt)
+	}
+	if tokenLives(b, old.TokenID) {
+		t.Error("cleanup dropped the session past max_token_age but left its token in the store")
+	}
+	if live := b.getSession(young.ID); live == nil {
+		t.Error("cleanup revoked a session that is neither expired nor past the ceiling")
+	}
+
+	// The token was revoked at the provider too, not just forgotten locally.
+	fake.mu.Lock()
+	revoked := append([]string(nil), fake.revoked...)
+	fake.mu.Unlock()
+	if len(revoked) != 1 || revoked[0] != "access-token-"+old.ID {
+		t.Errorf("provider saw revocations %v, want the aged-out session's token", revoked)
+	}
+}

--- a/pkg/auth/sanitize.go
+++ b/pkg/auth/sanitize.go
@@ -1,0 +1,142 @@
+package auth
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Provider-supplied strings end up on a terminal that nobody has authenticated
+// to yet. The broker hands the device-flow instructions to the PAM module over
+// IPC, and the module prints them with the conversation function while running
+// as root, before it knows who is logging in. Neither side filters them: the C
+// bridge bounds the length and nothing else.
+//
+// For github.com that is academic. For a configured GitHub Enterprise base_url
+// it is not: that server picks verification_uri and user_code, so whoever runs
+// it can put arbitrary bytes on the pre-auth terminal of every host configured
+// against it. A GHES operator is already trusted to decide who gets in; being
+// able to home the cursor, hide text, and draw a convincing password prompt over
+// the real one is a different and much larger capability, and there is no reason
+// to hand it over.
+//
+// Two policies, because the instruction text has two kinds of content:
+//
+//   - SanitizePromptValue for the untrusted values a provider chooses (the
+//     verification URI, the user code). A URL and a short code are single-line
+//     by definition — RFC 8628 has no notion of a multi-line verification_uri —
+//     so newline is removed along with everything else. This is deliberately
+//     stricter than the issue's "everything other than \n": a value that can
+//     emit a newline can start a line of its own, and a line of its own is what
+//     makes a fake prompt convincing. Confined to the middle of a template
+//     line, injected text reads as the garbage it is.
+//
+//   - SanitizePromptBlock for text whose newlines are structural, which in
+//     practice means the ASCII QR code. It keeps \n and removes everything else.
+//
+// The trusted template in qr_code.go is not sanitized at all: it is a constant
+// in this repository, its newlines are the layout, and running it through a
+// sanitizer would only make the layout depend on the sanitizer.
+//
+// Removing rather than escaping is a size decision. The module copies the
+// instructions into a fixed 16 KB buffer and strncpy truncates silently, so a
+// sanitizer that expanded ESC into a six-character escape would let a provider
+// amplify its way past the end of the prompt and cut off the trailing template.
+// Removal can only shrink. To keep removal from being silent, a value that lost
+// anything carries a marker saying so — an operator debugging a URL that does
+// not work needs to be able to tell tampering from a typo, and a user staring at
+// a login prompt needs a reason to be suspicious of what is above it.
+//
+// Note what is *not* filtered: bidirectional controls, zero-width joiners and
+// other confusables are left alone. They cannot move a cursor or hide a line,
+// they are legitimate in real text, and a deny-list that reached for them would
+// start breaking non-Latin values for no security gain.
+
+// sanitizeNote is the marker appended to a value the sanitizer had to alter.
+// It is plain ASCII so that it renders on a serial console and inside a GUI
+// login dialog, not just in a UTF-8 terminal emulator.
+const sanitizeNote = "[!] %d control character(s) removed"
+
+// SanitizePromptValue makes a provider-supplied single-line value safe to print
+// on a terminal. It removes every C0 control character (including newline, CR,
+// tab and ESC), DEL, every C1 control (U+0080-U+009F, which is where U+009B CSI
+// lives), and the Unicode line and paragraph separators, and it drops bytes that
+// are not valid UTF-8. Clean input is returned unchanged; input that lost
+// anything gains a visible note saying how much.
+func SanitizePromptValue(s string) string {
+	return sanitizeForPrompt(s, false)
+}
+
+// SanitizePromptBlock is SanitizePromptValue for pre-rendered multi-line text,
+// such as the ASCII QR code from GenerateQRCode: it keeps '\n', because those
+// newlines are the layout, and removes everything else SanitizePromptValue
+// removes. Passing the QR code through here is defence in depth rather than a
+// fix for a known path — go-qrcode's ToSmallString emits only block-drawing
+// runes and newlines whatever URL it encodes — and it is safe precisely because
+// keeping '\n' leaves that output untouched.
+func SanitizePromptBlock(s string) string {
+	return sanitizeForPrompt(s, true)
+}
+
+// isDisallowedInPrompt reports whether r must not reach a pre-auth terminal.
+// Newline is handled by the caller, which knows whether it is structural.
+func isDisallowedInPrompt(r rune) bool {
+	switch {
+	case r < 0x20: // C0: NUL, BS, TAB, LF, CR, ESC and friends
+		return true
+	case r == 0x7f: // DEL
+		return true
+	case r >= 0x80 && r <= 0x9f: // C1, e.g. U+0085 NEL and U+009B CSI
+		return true
+	case r == '\u2028', r == '\u2029': // LINE and PARAGRAPH SEPARATOR
+		return true
+	default:
+		return false
+	}
+}
+
+// sanitizeForPrompt walks s by rune, not by byte, because in valid UTF-8 a C1
+// control is two bytes (U+009B is 0xC2 0x9B) and a byte-wise filter would miss
+// it. Bytes that do not decode are dropped rather than replaced in place: a
+// stray 0x9B is a raw CSI to a terminal reading bytes, and turning it into
+// U+FFFD would hide the fact that the provider sent something malformed, which
+// the marker is there to surface.
+func sanitizeForPrompt(s string, allowNewline bool) string {
+	var b strings.Builder
+	removed := 0
+
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		start := i
+		i += size
+
+		switch {
+		case r == utf8.RuneError && size == 1: // not valid UTF-8
+			removed++
+		case r == '\n' && allowNewline:
+			b.WriteByte('\n')
+		case isDisallowedInPrompt(r):
+			removed++
+		default:
+			// Copy the original bytes rather than re-encoding the rune, so a
+			// value that needs no sanitizing is returned byte-for-byte.
+			b.WriteString(s[start:i])
+		}
+	}
+
+	if removed == 0 {
+		return s
+	}
+
+	note := fmt.Sprintf(sanitizeNote, removed)
+	out := b.String()
+	if !allowNewline {
+		return out + " " + note
+	}
+	// In block context the note belongs on a line of its own, or it would be
+	// read as part of the last row of the QR code.
+	if out != "" && !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	return out + note
+}

--- a/pkg/auth/sanitize_test.go
+++ b/pkg/auth/sanitize_test.go
@@ -1,0 +1,343 @@
+package auth
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// disallowedRunes reports every rune in s that must never reach a terminal in a
+// pre-auth prompt: C0 controls, DEL, the C1 block, and the Unicode line and
+// paragraph separators. Newline is allowed only when allowNewline is set, which
+// is true for a whole prompt (the instruction template is multi-line and
+// trusted) and false for an individual provider-supplied value.
+//
+// This is written out longhand rather than calling isDisallowedInPrompt so that
+// the test states the property independently of the code under test. A test that
+// asks the implementation what the right answer is cannot fail.
+func disallowedRunes(s string, allowNewline bool) []rune {
+	var found []rune
+	for _, r := range s {
+		if r == '\n' && allowNewline {
+			continue
+		}
+		switch {
+		case r < 0x20, // C0, including ESC, CR, TAB and NUL
+			r == 0x7f,              // DEL
+			r >= 0x80 && r <= 0x9f, // C1, e.g. U+009B CSI
+			r == '\u2028',          // LINE SEPARATOR
+			r == '\u2029':          // PARAGRAPH SEPARATOR
+			found = append(found, r)
+		}
+	}
+	return found
+}
+
+// assertNoDisallowedRunes fails the test if s carries any rune that could move
+// the cursor, hide text, or start a line where the template did not put one.
+func assertNoDisallowedRunes(t *testing.T, allowNewline bool, s string) {
+	t.Helper()
+	// A raw 0x9B byte is invalid UTF-8, so ranging over the string reports it as
+	// U+FFFD rather than as the C1 CSI it would be to a terminal reading bytes.
+	// Requiring valid UTF-8 is what closes that gap.
+	if !utf8.ValidString(s) {
+		t.Errorf("output is not valid UTF-8, so it may still carry raw C1 bytes: %q", s)
+	}
+	bad := disallowedRunes(s, allowNewline)
+	if len(bad) == 0 {
+		return
+	}
+	names := make([]string, 0, len(bad))
+	for _, r := range bad {
+		names = append(names, fmt.Sprintf("U+%04X", r))
+	}
+	t.Errorf("output carries %d control rune(s) %s; a provider must not be able to draw on a pre-auth terminal.\nOutput was %q",
+		len(bad), strings.Join(names, " "), s)
+}
+
+// assertMarked fails the test if the sanitizer removed something without saying
+// so. Silently handing the operator a mangled URL is its own failure mode: they
+// need to be able to tell tampering from a typo.
+func assertMarked(t *testing.T, in, got string) {
+	t.Helper()
+	if !strings.Contains(got, "control character") {
+		t.Errorf("sanitize(%q) = %q, want a visible marker saying something was removed", in, got)
+	}
+}
+
+// cleanValues are strings a well-behaved provider really does return. The
+// sanitizer must return each one byte-for-byte identical: an over-eager
+// sanitizer that mangles a legitimate verification URI breaks every login on
+// every host, which is a worse outcome than the injection it was written to
+// stop.
+var cleanValues = []string{
+	"https://github.com/login/device",
+	"https://github.com/login/device?user_code=WDJB-MJHT",
+	"https://ghes.corp.example:8443/login/device?user_code=WDJB-MJHT&next=%2Fhome",
+	"WDJB-MJHT",
+	"ABCD-1234",
+	"",
+	"a",                                   // one rune, nothing trailing, to catch a slicing bug
+	"https://sso.example/dévice",          // non-ASCII just above the C1 block
+	"code ─═ ABCD",                        // box drawing, as the template itself uses
+	"visit https://example/device — ABCD", // em dash
+	"\u00a0leading no-break space\u00a0",  // U+00A0 sits right after C1 and must survive
+}
+
+func TestSanitizePromptValueLeavesCleanInputUnchanged(t *testing.T) {
+	for _, in := range cleanValues {
+		t.Run(fmt.Sprintf("%q", in), func(t *testing.T) {
+			if got := SanitizePromptValue(in); got != in {
+				t.Errorf("SanitizePromptValue(%q) = %q, want it returned unchanged", in, got)
+			}
+		})
+	}
+}
+
+func TestSanitizePromptBlockLeavesCleanInputUnchanged(t *testing.T) {
+	// The block form additionally has to leave newlines alone, because it is
+	// applied to the pre-rendered ASCII QR code.
+	multiline := []string{"line one\nline two\n", "\n\n", "█▄\n▀█\n"}
+	for _, in := range append(multiline, cleanValues...) {
+		t.Run(fmt.Sprintf("%q", in), func(t *testing.T) {
+			if got := SanitizePromptBlock(in); got != in {
+				t.Errorf("SanitizePromptBlock(%q) = %q, want it returned unchanged", in, got)
+			}
+		})
+	}
+}
+
+func TestSanitizePromptValueRemovesControlCharacters(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		wantKept    string // the printable residue, before the marker
+		wantRemoved int
+	}{
+		{
+			name:        "ANSI CSI colour sequence",
+			in:          "\x1b[31mWDJB-MJHT\x1b[0m",
+			wantKept:    "[31mWDJB-MJHT[0m", // inert printable text once ESC is gone
+			wantRemoved: 2,
+		},
+		{
+			name:        "ANSI cursor movement and screen clear",
+			in:          "WDJB\x1b[2J\x1b[H\x1b[10;1f-MJHT",
+			wantKept:    "WDJB[2J[H[10;1f-MJHT",
+			wantRemoved: 3,
+		},
+		{
+			name:        "bare ESC",
+			in:          "WDJB\x1b-MJHT",
+			wantKept:    "WDJB-MJHT",
+			wantRemoved: 1,
+		},
+		{
+			name:        "carriage return, which overwrites the line the user just read",
+			in:          "https://real.example/device\rhttps://evil.example/device",
+			wantKept:    "https://real.example/devicehttps://evil.example/device",
+			wantRemoved: 1,
+		},
+		{
+			name:        "NUL",
+			in:          "WDJB\x00-MJHT",
+			wantKept:    "WDJB-MJHT",
+			wantRemoved: 1,
+		},
+		{
+			name:        "DEL",
+			in:          "WDJB\x7f-MJHT",
+			wantKept:    "WDJB-MJHT",
+			wantRemoved: 1,
+		},
+		{
+			name:        "backspace, which rewrites what is already on screen",
+			in:          "WDJB\b\b\b\bXXXX",
+			wantKept:    "WDJBXXXX",
+			wantRemoved: 4,
+		},
+		{
+			name:        "tab, which shifts the column the value sits in",
+			in:          "WDJB\t-MJHT",
+			wantKept:    "WDJB-MJHT",
+			wantRemoved: 1,
+		},
+		{
+			// U+009B is CSI. On a terminal that honours 8-bit controls it does
+			// everything ESC-[ does, in one rune, and in valid UTF-8 it arrives
+			// as two bytes (0xC2 0x9B) rather than as a raw 0x9B.
+			name:        "C1 runes, which are U+0080-U+009F and not raw bytes",
+			in:          "WDJB\u009b31m\u0085\u009f-MJHT",
+			wantKept:    "WDJB31m-MJHT",
+			wantRemoved: 3,
+		},
+		{
+			name:        "newline, which a URL and a short code never legitimately contain",
+			in:          "https://evil.example/device\n\nsomething else",
+			wantKept:    "https://evil.example/devicesomething else",
+			wantRemoved: 2,
+		},
+		{
+			name:        "Unicode line and paragraph separators, newlines by another name",
+			in:          "WDJB\u2028-MJHT\u2029",
+			wantKept:    "WDJB-MJHT",
+			wantRemoved: 2,
+		},
+		{
+			// The whole point of the finding: a hostile GitHub Enterprise
+			// verification_uri that clears the screen and draws its own prompt
+			// on a root pre-auth terminal.
+			name:        "a plausible fake password prompt",
+			in:          "https://ghes.corp.example/login/device\x1b[2J\x1b[H\x1b[1;1fPassword: \x1b[8m",
+			wantKept:    "https://ghes.corp.example/login/device[2J[H[1;1fPassword: [8m",
+			wantRemoved: 4,
+		},
+		{
+			name:        "only control characters leaves nothing but the marker",
+			in:          "\x1b\x1b\x00",
+			wantKept:    "",
+			wantRemoved: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizePromptValue(tt.in)
+
+			assertNoDisallowedRunes(t, false, got)
+			assertMarked(t, tt.in, got)
+
+			if !strings.HasPrefix(got, tt.wantKept) {
+				t.Errorf("SanitizePromptValue(%q) = %q, want it to start with the printable residue %q",
+					tt.in, got, tt.wantKept)
+			}
+			if !strings.Contains(got, fmt.Sprintf("%d", tt.wantRemoved)) {
+				t.Errorf("SanitizePromptValue(%q) = %q, want the marker to report %d removed rune(s)",
+					tt.in, got, tt.wantRemoved)
+			}
+		})
+	}
+}
+
+func TestSanitizePromptBlockRemovesEverythingButNewline(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantKept string
+	}{
+		{
+			name:     "escape sequence between lines",
+			in:       "line one\n\x1b[2Jline two\n",
+			wantKept: "line one\n[2Jline two\n",
+		},
+		{
+			name:     "C1 CSI",
+			in:       "block\u009b31m\n",
+			wantKept: "block31m\n",
+		},
+		{
+			name:     "carriage return is not a newline",
+			in:       "line one\r\nline two",
+			wantKept: "line one\nline two",
+		},
+		{
+			name:     "Unicode line separator is not a newline either",
+			in:       "line one\u2028line two",
+			wantKept: "line oneline two",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizePromptBlock(tt.in)
+
+			assertNoDisallowedRunes(t, true, got)
+			assertMarked(t, tt.in, got)
+
+			if !strings.HasPrefix(got, tt.wantKept) {
+				t.Errorf("SanitizePromptBlock(%q) = %q, want it to start with %q", tt.in, got, tt.wantKept)
+			}
+		})
+	}
+}
+
+// TestSanitizePromptBlockLeavesARealQRCodeIntact is the guard on the qrCode
+// decision. GenerateQRCode's output is block-drawing runes separated by
+// newlines, so the block policy has to pass it through untouched: a sanitizer
+// that stripped its newlines would collapse the QR code into one unreadable
+// line for every user on every login.
+func TestSanitizePromptBlockLeavesARealQRCodeIntact(t *testing.T) {
+	qr, err := GenerateQRCode(testDeviceURL)
+	if err != nil {
+		t.Fatalf("GenerateQRCode: %v", err)
+	}
+	if !strings.Contains(qr, "\n") {
+		t.Fatal("a QR code is expected to be multi-line; this test proves nothing otherwise")
+	}
+
+	if got := SanitizePromptBlock(qr); got != qr {
+		t.Errorf("SanitizePromptBlock mangled a real QR code.\nbefore (%d bytes, %d lines):\n%s\nafter (%d bytes, %d lines):\n%s",
+			len(qr), strings.Count(qr, "\n"), qr, len(got), strings.Count(got, "\n"), got)
+	}
+}
+
+// TestSanitizingCannotAmplify pins the reason the sanitizer removes rather than
+// escapes. The module copies the instructions into a fixed 16 KB buffer and
+// strncpy truncates silently, so if sanitizing could make a value longer than it
+// arrived, a provider could pad its way past the end of the prompt and cut the
+// trusted trailer off the bottom. Removal plus one fixed marker cannot.
+func TestSanitizingCannotAmplify(t *testing.T) {
+	const markerAllowance = 64 // "[!] N control character(s) removed", plus a separator
+
+	inputs := []string{
+		strings.Repeat("\x1b", 4096),
+		strings.Repeat("\u009b", 4096),
+		strings.Repeat("\u2028", 4096),
+		strings.Repeat("\xff", 4096),
+		strings.Repeat("\x1b[31m", 512),
+		hostileDeviceURL,
+		hostileUserCode,
+	}
+
+	for name, sanitize := range map[string]func(string) string{
+		"value": SanitizePromptValue,
+		"block": SanitizePromptBlock,
+	} {
+		for i, in := range inputs {
+			t.Run(fmt.Sprintf("%s/%d", name, i), func(t *testing.T) {
+				if got := sanitize(in); len(got) > len(in)+markerAllowance {
+					t.Errorf("sanitizing grew %d bytes into %d; a provider must not be able to pad the prompt past the module's buffer",
+						len(in), len(got))
+				}
+			})
+		}
+	}
+}
+
+// TestSanitizeDropsMalformedUTF8 pins the byte-versus-rune question. Provider
+// output is not guaranteed to be valid UTF-8, and a stray high byte must not
+// survive into a prompt: it is exactly how a raw 0x9B CSI would arrive.
+func TestSanitizeDropsMalformedUTF8(t *testing.T) {
+	in := "WDJB\xc3-MJHT\x80\xff\x9b"
+
+	for name, sanitize := range map[string]func(string) string{
+		"value": SanitizePromptValue,
+		"block": SanitizePromptBlock,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := sanitize(in)
+
+			if !utf8.ValidString(got) {
+				t.Errorf("sanitize(%q) = %q, which is not valid UTF-8", in, got)
+			}
+			if strings.ContainsRune(got, utf8.RuneError) {
+				t.Errorf("sanitize(%q) = %q, want malformed bytes dropped rather than replaced in place", in, got)
+			}
+			if !strings.HasPrefix(got, "WDJB-MJHT") {
+				t.Errorf("sanitize(%q) = %q, want the valid runes kept and the malformed bytes dropped", in, got)
+			}
+			assertMarked(t, in, got)
+		})
+	}
+}

--- a/pkg/auth/sanitize_wire_test.go
+++ b/pkg/auth/sanitize_wire_test.go
@@ -1,0 +1,96 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/oauth2-pam/pkg/provider"
+)
+
+// hostileProvider is a provider whose device flow returns strings laced with
+// terminal escapes, as a compromised or malicious GitHub Enterprise deployment
+// would: it chooses verification_uri and user_code, and every host configured
+// against it prints them.
+type hostileProvider struct {
+	*fakeProvider
+}
+
+// The payload clears the screen, homes the cursor, draws a fake password prompt
+// and turns off local echo — the shape of an attack that harvests a Unix password
+// from a user who believes they are still talking to sshd.
+const hostilePayload = "\x1b[2J\x1b[H\x1b[1;1fPassword: \x1b[8m"
+
+func (h hostileProvider) StartDeviceFlow(ctx context.Context) (*provider.DeviceFlow, error) {
+	df, err := h.fakeProvider.StartDeviceFlow(ctx)
+	if err != nil {
+		return nil, err
+	}
+	df.UserCode = "ABCD-1234" + hostilePayload
+	df.DeviceURL = "https://ghes.corp.example/login/device" + hostilePayload
+	return df, nil
+}
+
+// TestWireFieldsFromAProviderAreSanitized covers the half of #45 that sanitizing
+// the prompt formatters does not reach.
+//
+// A reply carries device_url, device_code and qr_code as their own fields, and
+// docs/wire-protocol.md describes them as "the parts, for a client that wants to
+// format its own prompt" — so a consumer this project does not control is
+// explicitly invited to draw them on a pre-auth terminal. Cleaning them inside
+// this implementation's formatters would leave that consumer holding raw provider
+// bytes. The contract has to be clean at the boundary.
+//
+// The escapes must not survive anywhere in the response, so this asserts the
+// property on every field a client might print rather than on one of them.
+func TestWireFieldsFromAProviderAreSanitized(t *testing.T) {
+	fake := newFakeProvider("ghes")
+	b := startBroker(t, brokerConfig(t), hostileProvider{fake})
+
+	resp, err := b.Authenticate(&AuthRequest{UserID: "alice", LoginType: "ssh"})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if resp.Status != StatusPending {
+		t.Fatalf("status = %q, want pending", resp.Status)
+	}
+
+	// Single-line values: no control characters at all, newline included. A value
+	// that can emit a newline can start a line of its own, and a line of its own is
+	// what makes a forged prompt convincing.
+	for _, f := range []struct{ name, got string }{
+		{"device_url", resp.DeviceURL},
+		{"device_code", resp.DeviceCode},
+	} {
+		if f.got == "" {
+			t.Errorf("%s is empty; sanitizing must not discard the value", f.name)
+		}
+		assertNoDisallowedRunes(t, false, f.got)
+	}
+
+	// qr_code and instructions are multi-line by construction, so newline is the
+	// one thing they may contain.
+	assertNoDisallowedRunes(t, true, resp.QRCode)
+
+	// ESC is the character every one of these attacks needs; check for it by name
+	// as well, so a future sanitizer that somehow permits it fails loudly here and
+	// not only through the rune predicate it might share a bug with.
+	for _, f := range []struct{ name, got string }{
+		{"device_url", resp.DeviceURL},
+		{"device_code", resp.DeviceCode},
+		{"qr_code", resp.QRCode},
+	} {
+		if strings.ContainsRune(f.got, 0x1b) {
+			t.Errorf("%s still contains ESC: %q", f.name, f.got)
+		}
+	}
+
+	// The legitimate part of each value must survive; a sanitizer that dropped
+	// everything would pass every assertion above.
+	if !strings.HasPrefix(resp.DeviceCode, "ABCD-1234") {
+		t.Errorf("device_code = %q, want it to still begin with the real code", resp.DeviceCode)
+	}
+	if !strings.HasPrefix(resp.DeviceURL, "https://ghes.corp.example/login/device") {
+		t.Errorf("device_url = %q, want it to still begin with the real URL", resp.DeviceURL)
+	}
+}

--- a/pkg/enrollment/store.go
+++ b/pkg/enrollment/store.go
@@ -41,6 +41,25 @@ type Store struct {
 	Enrollments []Record `yaml:"enrollments"`
 }
 
+// LocalUserValidator reports whether localUser is a name a *new* enrollment may
+// use. Add takes one.
+//
+// It is a function rather than a check written out here because the authoritative
+// rules — the Unix-name shape, the system-account denylist, the mapper.min_uid
+// floor — belong to pkg/mapper, which imports this package. Restating them here
+// would mean a second copy that can drift from the gate it is predicting, and a
+// write-time rule that is looser than the login-time one is worse than no
+// write-time rule at all. So the writer supplies the mapper's own gate:
+// mapper.Chain.ValidateLocalUser.
+type LocalUserValidator func(localUser string) error
+
+// Unvalidated is what a caller passes to Add when it has no mapper configuration
+// to validate against, and therefore cannot say whether the name it is recording
+// could ever authenticate. Named rather than a bare nil so that the callers making
+// that choice can be found by grep. Production writers should pass the mapper's
+// gate; a record that fails it is one the mapper will refuse at login.
+var Unvalidated LocalUserValidator
+
 // Load reads the enrollment file at path. If the file does not exist, an
 // empty Store is returned without error.
 func Load(path string) (*Store, error) {
@@ -172,11 +191,24 @@ func (s *Store) FindByLocalUser(localUser string) *Record {
 }
 
 // Add appends a new enrollment record. Returns an error if a record for the
-// same local user already exists (use Remove first to re-enroll).
-func (s *Store) Add(rec Record) error {
+// same local user already exists (use Remove first to re-enroll), or if validate
+// refuses rec.LocalUser.
+//
+// validate is applied to the new record only, and only here — never on Load or
+// Save. A record already in the file, however it got there, must not stop the
+// store from loading or from being written back: the mapper refuses such a record
+// at login on its own, and making Load fail would turn one unusable enrollment
+// into a broken enrollment file for everybody, including the operator trying to
+// remove it. Pass Unvalidated if there is no configuration to validate against.
+func (s *Store) Add(rec Record, validate LocalUserValidator) error {
 	if existing := s.FindByLocalUser(rec.LocalUser); existing != nil {
 		return fmt.Errorf("local user %q is already enrolled as %q; remove first",
 			rec.LocalUser, existing.Login)
+	}
+	if validate != nil {
+		if err := validate(rec.LocalUser); err != nil {
+			return fmt.Errorf("local user %q may not be enrolled: %w", rec.LocalUser, err)
+		}
 	}
 	s.Enrollments = append(s.Enrollments, rec)
 	return nil

--- a/pkg/enrollment/store_test.go
+++ b/pkg/enrollment/store_test.go
@@ -1,6 +1,8 @@
 package enrollment
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -161,11 +163,11 @@ func TestFindByLocalUser(t *testing.T) {
 func TestAddRejectsDuplicateLocalUser(t *testing.T) {
 	store := &Store{}
 
-	if err := store.Add(Record{LocalUser: "alice", Login: "alice-gh"}); err != nil {
+	if err := store.Add(Record{LocalUser: "alice", Login: "alice-gh"}, Unvalidated); err != nil {
 		t.Fatalf("first Add: %v", err)
 	}
 
-	err := store.Add(Record{LocalUser: "alice", Login: "mallory-gh"})
+	err := store.Add(Record{LocalUser: "alice", Login: "mallory-gh"}, Unvalidated)
 	if err == nil {
 		t.Fatal("Add silently re-enrolled an existing local user under a different GitHub account")
 	}
@@ -182,10 +184,10 @@ func TestAddRejectsDuplicateLocalUser(t *testing.T) {
 
 func TestAddDuplicateIsCaseInsensitive(t *testing.T) {
 	store := &Store{}
-	if err := store.Add(Record{LocalUser: "alice", Login: "alice-gh"}); err != nil {
+	if err := store.Add(Record{LocalUser: "alice", Login: "alice-gh"}, Unvalidated); err != nil {
 		t.Fatalf("first Add: %v", err)
 	}
-	if err := store.Add(Record{LocalUser: "ALICE", Login: "mallory-gh"}); err == nil {
+	if err := store.Add(Record{LocalUser: "ALICE", Login: "mallory-gh"}, Unvalidated); err == nil {
 		t.Error("Add accepted a duplicate that differed only in case")
 	}
 }
@@ -222,11 +224,167 @@ func TestRemoveThenAddAllowsReEnrollment(t *testing.T) {
 	if !store.Remove("alice") {
 		t.Fatal("Remove failed")
 	}
-	if err := store.Add(Record{LocalUser: "alice", Login: "alice-new-gh"}); err != nil {
+	if err := store.Add(Record{LocalUser: "alice", Login: "alice-new-gh"}, Unvalidated); err != nil {
 		t.Fatalf("re-enrollment after Remove: %v", err)
 	}
 	if rec := store.FindByLocalUser("alice"); rec == nil || rec.Login != "alice-new-gh" {
 		t.Errorf("record = %+v, want the new GitHub login", rec)
+	}
+}
+
+// --- the write-time local-user gate ---
+
+// forbidden is a stand-in for the real gate. pkg/mapper owns the rules and imports
+// this package, so a test here cannot call them; what it can pin is that Add asks,
+// that a refusal stops the record entering the store, and that the reason survives
+// to the caller. The rules themselves are checked against mapper's own gate in
+// pkg/mapper and in cmd/oauth2-pam-enroll.
+var errForbidden = errors.New("forbidden local account")
+
+func forbidding(names ...string) LocalUserValidator {
+	deny := make(map[string]bool, len(names))
+	for _, n := range names {
+		deny[n] = true
+	}
+	return func(localUser string) error {
+		if deny[localUser] {
+			return fmt.Errorf("%w: %q", errForbidden, localUser)
+		}
+		return nil
+	}
+}
+
+// TestAddAppliesTheLocalUserValidator: a record that could never authenticate must
+// not be written in the first place. Before this, oauth2-pam-enroll wrote it and
+// the operator found out at the denied login.
+func TestAddAppliesTheLocalUserValidator(t *testing.T) {
+	// The shapes the mapper's gate refuses, as a reminder of what the CLI is
+	// wiring in: root, a denylisted service account, and names no Unix account can
+	// have.
+	bad := []string{
+		"root",
+		"www-data",
+		"systemd-resolve",
+		"Alice",
+		"1alice",
+		strings.Repeat("a", 33),
+		"al/ice",
+		"al\x00ice",
+		"",
+	}
+
+	for _, name := range bad {
+		t.Run(name, func(t *testing.T) {
+			store := &Store{}
+			err := store.Add(Record{LocalUser: name, Login: "attacker"}, forbidding(bad...))
+			if err == nil {
+				t.Fatalf("Add(%q) succeeded; the validator's refusal was ignored", name)
+			}
+			if !errors.Is(err, errForbidden) {
+				t.Errorf("err = %v, want it to wrap the validator's error", err)
+			}
+			if len(store.Enrollments) != 0 {
+				t.Errorf("got %d records, want the store unchanged after a refusal", len(store.Enrollments))
+			}
+		})
+	}
+}
+
+// The other half: a permissible account still enrolls, and comes back off disk
+// exactly as it went in.
+func TestAddAValidUserStillRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrolled-users.yaml")
+	enrolledAt := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	rec := Record{
+		LocalUser:  "alice",
+		Login:      "alice-gh",
+		Provider:   "corp-github",
+		EnrolledAt: enrolledAt,
+		EnrolledBy: "root",
+		Groups:     []string{"devs"},
+	}
+
+	store := &Store{}
+	if err := store.Add(rec, forbidding("root", "www-data")); err != nil {
+		t.Fatalf("Add of a permissible account: %v", err)
+	}
+	if err := store.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Enrollments) != 1 {
+		t.Fatalf("got %d records, want 1", len(loaded.Enrollments))
+	}
+	got := loaded.Enrollments[0]
+	if got.LocalUser != rec.LocalUser || got.Login != rec.Login || got.Provider != rec.Provider ||
+		got.EnrolledBy != rec.EnrolledBy || !got.EnrolledAt.Equal(rec.EnrolledAt) ||
+		len(got.Groups) != 1 || got.Groups[0] != "devs" {
+		t.Errorf("record = %+v, want %+v", got, rec)
+	}
+}
+
+// TestAPreExistingForbiddenRecordDoesNotBreakTheFile is the backward-compatibility
+// guarantee. Files written before the write-time gate existed may name accounts it
+// would refuse. Validating on Load — or on Save — would take a single unusable
+// enrollment and turn it into an enrollment file nobody can read or repair, which
+// is an outage in place of a UX gap. The mapper refuses such a record at login on
+// its own.
+func TestAPreExistingForbiddenRecordDoesNotBreakTheFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrolled-users.yaml")
+	legacy := `enrollments:
+  - local_user: root
+    login: mallory
+    enrolled_by: root
+  - local_user: BadName
+    login: bob
+    enrolled_by: root
+  - local_user: alice
+    login: alice-gh
+    enrolled_by: root
+`
+	if err := os.WriteFile(path, []byte(legacy), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load of a store holding a forbidden record: %v", err)
+	}
+	if len(store.Enrollments) != 3 {
+		t.Fatalf("got %d records, want all 3 loaded", len(store.Enrollments))
+	}
+	if store.FindByLocalUser("root") == nil {
+		t.Error("the forbidden record was silently dropped on load; --remove could never reach it")
+	}
+
+	gate := forbidding("root", "BadName")
+
+	// Adding somebody else is not blocked by the record already there: only the
+	// new name is validated.
+	if err := store.Add(Record{LocalUser: "carol", Login: "carol-gh"}, gate); err != nil {
+		t.Fatalf("Add beside a pre-existing forbidden record: %v", err)
+	}
+
+	// And the file can still be written back — which is what --remove needs.
+	if !store.Remove("root") {
+		t.Error("Remove could not delete the forbidden record")
+	}
+	if err := store.Save(path); err != nil {
+		t.Fatalf("Save of a store still holding a forbidden record: %v", err)
+	}
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load after Save: %v", err)
+	}
+	if reloaded.FindByLocalUser("BadName") == nil {
+		t.Error("Save dropped the remaining pre-existing record")
+	}
+	if reloaded.FindByLocalUser("carol") == nil {
+		t.Error("the newly added record did not survive the save")
 	}
 }
 

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -545,6 +545,30 @@ func lookupSystemUID(name string) (int, error) {
 	return uid, nil
 }
 
+// ValidateLocalUser applies checkLocalUser — the gate below, the one every tier's
+// answer passes through — to a candidate local account name outside of a mapping,
+// so that something which *writes* a mapping (an enrollment, today) can refuse a
+// name at the moment it is typed rather than leaving it to be refused at the login
+// it will deny. source names the caller in the error ("enrollment").
+//
+// It calls checkLocalUser deliberately, rather than re-stating the regexp and the
+// denylist: a second copy of the rules could drift from the gate it exists to
+// predict, and a write-time check more permissive than the login-time one is
+// exactly the confusion it is meant to remove. A name this accepts is a name Map
+// will accept, on this host, with this config.
+//
+// This is not the control. Map gates every tier including tier 0, so a record
+// naming root or a system account fails closed at authentication whether or not it
+// was ever validated here; this is so the operator hears about it at the point they
+// can still fix it cheaply.
+//
+// An account that does not resolve on this host is accepted with a warning,
+// exactly as at login time: without a UID the floor cannot be applied, and
+// enrolling a user before their account is created is legitimate.
+func (c *Chain) ValidateLocalUser(source, name string) error {
+	return c.checkLocalUser(source, name)
+}
+
 // checkLocalUser is the gate every tier's answer passes through. It refuses names
 // that are not valid Unix usernames, system accounts, and accounts below the UID
 // floor.

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -306,6 +306,102 @@ func TestEnrollmentWithInvalidUsernameIsSkipped(t *testing.T) {
 	}
 }
 
+// --- the exported gate, for write-time callers ---
+
+// TestValidateLocalUserRefusesWhatTheTiersRefuse pins the exported gate against
+// the same cases checkLocalUser refuses for a tier: the name shape, the
+// system-account denylist, root by UID, and the min_uid floor.
+func TestValidateLocalUserRefusesForbiddenAccounts(t *testing.T) {
+	passwd := map[string]int{"root": 0, "www-data": 33, "svc": 120, "alice": 1000}
+	cfg := config.MapperConfig{}
+
+	forbidden := []struct {
+		name, why string
+	}{
+		{"root", "UID 0"},
+		{"www-data", "a denylisted service account"},
+		{"systemd-resolve", "a denylisted prefix"},
+		{"svc", "below the min_uid floor"},
+		{"Alice", "uppercase"},
+		{"1alice", "leading digit"},
+		{strings.Repeat("a", 33), "over 32 characters"},
+		{"al/ice", "an embedded slash"},
+		{"al\x00ice", "an embedded NUL"},
+		{"", "empty"},
+	}
+	for _, tc := range forbidden {
+		t.Run(tc.why, func(t *testing.T) {
+			c := chainWithPasswd(t, cfg, passwd)
+			err := c.ValidateLocalUser("enrollment", tc.name)
+			if !errors.Is(err, ErrForbiddenLocalUser) {
+				t.Fatalf("ValidateLocalUser(%q) error = %v, want ErrForbiddenLocalUser", tc.name, err)
+			}
+			if !strings.Contains(err.Error(), "enrollment") {
+				t.Errorf("error = %q, want it to name the caller so the operator knows what refused", err)
+			}
+		})
+	}
+
+	// The control: an ordinary account above the floor is accepted.
+	c := chainWithPasswd(t, cfg, passwd)
+	if err := c.ValidateLocalUser("enrollment", "alice"); err != nil {
+		t.Errorf("ValidateLocalUser(alice): %v", err)
+	}
+
+	// And an account that does not resolve here is accepted, deliberately: the
+	// floor cannot be applied without a UID, and enrolling a user before their
+	// account exists — or one who lives in LDAP on a broker built without cgo — is
+	// legitimate. This mirrors login time exactly; see
+	// TestUnresolvableAccountPassesTheFloorButNotTheDenylist.
+	c = chainWithPasswd(t, cfg, passwd)
+	if err := c.ValidateLocalUser("enrollment", "notyetcreated"); err != nil {
+		t.Errorf("ValidateLocalUser refused an account that does not exist yet: %v", err)
+	}
+}
+
+// TestValidateLocalUserAgreesWithMap is the reason the write-time check calls the
+// mapper's gate instead of restating its rules: a name accepted at enrollment must
+// be one the login path accepts, and vice versa. If the two ever drift, this fails.
+func TestValidateLocalUserAgreesWithMap(t *testing.T) {
+	passwd := map[string]int{"root": 0, "www-data": 33, "svc": 120, "alice": 1000, "bob": 1001}
+	// "" is left out because it is not a name a login can request: Map skips tier 0
+	// entirely when requestedLocalUser is empty, so there is no read-time answer to
+	// compare against.
+	names := []string{
+		"root", "www-data", "systemd-resolve", "svc", "Alice", "1alice",
+		strings.Repeat("a", 33), "alice", "bob", "notyetcreated",
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			id := identityWithLogin("attacker")
+
+			// Write-time: what the enroll path would be told.
+			gate := chainWithPasswd(t, config.MapperConfig{}, passwd)
+			writeErr := gate.ValidateLocalUser("enrollment", name)
+
+			// Read-time: the same name reaching Map through tier 0.
+			path := writeEnrollment(t, enrollment.Record{
+				LocalUser: name,
+				Login:     "attacker",
+				Provider:  "github",
+			})
+			c := chainWithPasswd(t, config.MapperConfig{
+				EnrollmentEnabled: true,
+				EnrollmentFile:    path,
+			}, passwd)
+			_, readErr := c.Map(context.Background(), id, name)
+
+			// Map can refuse either as forbidden or as no-mapping (an unusable name
+			// is skipped by tier 0); what must agree is whether it refuses at all.
+			if (writeErr != nil) != (readErr != nil) {
+				t.Fatalf("local_user %q: write-time err = %v, login-time err = %v; the two gates disagree",
+					name, writeErr, readErr)
+			}
+		})
+	}
+}
+
 func TestMissingEnrollmentFileFallsThrough(t *testing.T) {
 	c := New(config.MapperConfig{
 		EnrollmentEnabled: true,


### PR DESCRIPTION
Fixes the six findings from the deep security review. One commit per finding, each with its own tests; the changelog is a seventh.

| Commit | Issue | What was wrong |
|---|---|---|
| `ad0f8d9` | #41, #43 | `refresh_session` extended expired sessions and ignored `max_token_age`; the write-back was not a compare-and-set |
| `6e870d6` | #45 | Provider-chosen strings reached a pre-auth terminal unfiltered |
| `93f97e7` | #42 | The session rate limiter's map grew without bound on caller-chosen keys |
| `8fcb4e2` | #44 | The socket's documented access model was not the one that exists |
| `70fbd03` | #46 | `oauth2-pam-enroll` accepted local accounts the mapper would refuse |

### The two that are exploitable as shipped

**#41 — an expired session came back authorized.** `CheckSession` removes an expired session and answers `SESSION_EXPIRED`. `RefreshSession` had no expiry check at all, and `time.Until` of a past instant is negative, so an expired session fell through the `> RefreshThreshold` guard into the extend branch and got a fresh lifetime, `success: true` and the mapped `user_id` — the tuple the PAM module grants a login on. Two wire verbs disagreed about the same session, so a client could pick the one that was wrong. There is no in-tree caller of `refresh_session`, which is what makes this latent rather than live here — but this project owns the protocol and makes the verb normative for oidc-pam.

**#45 — a provider could draw on the terminal.** `user_code` and `verification_uri` are chosen by the provider and printed by a root process to the terminal of someone who has not authenticated yet. `\x1b[2J\x1b[H\x1b[1;1fPassword: \x1b[8m` clears the screen, draws a password prompt and turns off echo. Theoretical for github.com; not theoretical for a configured Enterprise `base_url`.

### Two judgement calls worth a reviewer's attention

**Sanitizing strips, it does not escape.** The C module `strncpy`s `instructions` into a fixed 16 KiB buffer and truncates silently, so an escaping sanitizer — up to 6× expansion — would let a provider pad the prompt until the trusted trailer fell off the end. Stripping can only shrink. `TestSanitizingCannotAmplify` holds that property against a future rewrite; it fails an escaping implementation with *"sanitizing grew 4096 bytes into 24614"*.

**Sanitizing happens at the `AuthResponse` boundary, not in the formatters.** Cleaning the three prompt formatters looked sufficient and is not: the reply also carries `device_url` and `device_code` as their own fields, and `docs/wire-protocol.md` offers them as "the parts, for a client that wants to format its own prompt". A consumer that accepts that invitation would hold raw provider bytes. `TestWireFieldsFromAProviderAreSanitized` covers that half.

### #44 is a docs change, and that is the point

Reality was *safer* than the comments — there is no `os.Chown` in the repo and the unit runs `root:root` — but the comments described a group-based model that would have widened the boundary if someone had implemented what they read. Several other findings here are rated low purely because only root can reach the socket, so that fact is now stated normatively and the note tells anyone changing it to re-rate those findings first.

### Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` all clean; `go test -race -count=1 ./...` green.
- Every fix was mutation-checked rather than trusted: reverting `evictNow`, the `ValidateLocalUser` body, `isDisallowedInPrompt`, the expiry check, the compare-and-set, and the broker's sanitize calls each makes a specific test fail.
- The resurrection race is invisible to `-race` — every access is correctly locked, the wrong *value* is written — so it is pinned by 32 concurrent refresh/revoke pairs per round. One pair per round missed the bug on most runs and never caught it at `GOMAXPROCS=1`.

### Follow-ups filed, not done here

- #50 — `Broker.SessionExists` and `TokenManager.Has`. Both the #42 and #41 fixes worked around the same missing predicate; the workarounds carry comments pointing at it.
- #49 records that the audit log is already safe from the #45 class of payload (`json.Marshal` escapes control characters), so nobody re-fixes it.

Unblocks #47 (v0.3.0).

Closes #41
Closes #42
Closes #43
Closes #44
Closes #45
Closes #46