### PR TITLE
Close two silences in wire protocol version 1 (#52, part of #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Version 1 says what an absent `source_ip` means, and that a zoned IPv6
+  literal must be accepted.** Both were silences, and both cost a sister project a
+  real bug: a broker enforcing "private networks only" read `net.ParseIP("")` as
+  "not private" and refused *every* login on the host, reporting an unknown origin
+  as a public one. The spec now states that an absent value is `unknown`, a third
+  answer, and that `unknown` never satisfies a network requirement — while leaving
+  the resolution (deny, or an audited waiver) to the broker, since that is policy.
+  It also requires a receiver to accept `fe80::1%eth0`: it is inside the 45-byte
+  bound the field always had, and it is the one address shape a well-meaning
+  validator breaks, because `net.ParseIP` and `inet_pton` both fail on a zone. This
+  implementation length-bounds `source_ip` and parses nothing, so it already
+  conformed; `TestValidateRequest` now pins that. And `metadata.rhost` may be a
+  resolved hostname — which is what makes the address-only rule on `source_ip`
+  affordable, and is why nothing may read it for an authorization decision.
+  ([#52](https://github.com/scttfrdmn/oauth2-pam/issues/52))
+- **`RESPONSE_TOO_LARGE` is a registered `error_code`.** `oidc-pam` sends it, and
+  by version 1's own rule an error code a second implementation reads is contract
+  rather than local dialect. It is terminal, and it buys a client the difference
+  between "the broker sent something I could not parse" and "the broker had
+  something to say and it did not fit". Whether a broker is *obliged* to substitute
+  it — rather than writing an oversized reply and leaving the client to refuse —
+  is deliberately left open; that is a requirement this broker does not yet meet,
+  and both the spec and [#48](https://github.com/scttfrdmn/oauth2-pam/issues/48)
+  say so rather than implying a guarantee.
 - **The wire contract is written down and versioned.**
   [`docs/wire-protocol.md`](docs/wire-protocol.md) specifies the broker↔module
   protocol as a contract rather than as a description of one implementation, and

--- a/docs/wire-protocol.md
+++ b/docs/wire-protocol.md
@@ -175,7 +175,7 @@ with `status`.
 | `user_id` | string | The **local account being logged into** — the PAM username, not the provider's. Required and non-empty for `authenticate`. Max 256 bytes, no NUL. |
 | `session_id` | string | Required for the session verbs. Max 128 bytes. |
 | `provider` | string | Optional. Names a configured provider; absent means the broker's default. A name that is not configured is refused rather than replaced by the default. Max 256 bytes, no NUL. |
-| `source_ip` | string | The client address, if the login has one and it really is an address. Max 45 bytes (an IPv6 literal with a scope). A resolved hostname does not belong here. |
+| `source_ip` | string | The client address, if the login has one and it really is an address. Max 45 bytes (an IPv6 literal with a scope). A resolved hostname does not belong here. See below: a receiver **must** accept a zone, and an absent value means *origin unknown*. |
 | `target_host` | string | The host being logged **into** — this host. Max 253 bytes. |
 | `login_type` | string | `ssh`, `console`, or `gui`. Optional; empty is treated as `ssh`. Any other value is refused. It selects how instructions are formatted, nothing more. |
 | `user_agent`, `device_id` | string | Optional, carried into the audit trail. |
@@ -187,6 +187,46 @@ authorized. The whole authorization decision is that those two agree, so a clien
 that conflates them has no check left. `source_ip` is where the login came from
 and `target_host` is where it is going; this project shipped them backwards once,
 which made every audit record name the client as the host being logged into.
+
+#### `source_ip`, in three parts
+
+All three of these were silences in this document that cost a real implementation a
+real bug (`oidc-pam#169`, where both ends sent `PAM_RHOST` as `target_host` and no
+`source_ip` at all). They are stated normatively because a client cannot otherwise
+know whether what it sends is safe.
+
+**A receiver must accept a zoned IPv6 literal.** `fe80::1%eth0` is inside the
+45-byte bound and is what a link-local login looks like, but the obvious validator
+rejects it: Go's `net.ParseIP` fails on a zone and C's `inet_pton(AF_INET6, …)`
+fails on one too. So a broker that validates the naive way refuses a login whose
+length this table explicitly sized for. Strip the zone, validate the address,
+and — if the value is forwarded or logged — forward it with the zone intact: the
+zone is which interface the peer is on, which is not redundant with the address.
+
+**An absent `source_ip` means the origin is unknown, and unknown is never
+equivalent to a satisfied network requirement.** A console login genuinely has no
+source address, so absence is legitimate and a broker must not treat it as a
+malformed request. But a broker enforcing something like "private networks only"
+cannot answer that requirement from an absent value, and both of the readings it
+might reach for on its own are silent failures: treating absent as *not* private
+refuses every console login and reports the origin as public when it is merely
+unknown, and treating absent as *satisfying* the requirement makes the requirement
+bypassable by omitting one optional field.
+
+This document does not choose the resolution — deny by default, or an explicit
+operator waiver, is a broker's policy decision. What it fixes is the premise: an
+absent value is `unknown`, a third answer, and a network requirement is not met by
+it. A broker that has such a requirement configured must decide what `unknown`
+does *before* it can be asked, and say so in its own configuration rather than
+arriving at it by accident inside a validator.
+
+**`metadata.rhost` may be a resolved hostname.** That is the reason the
+address-only restriction on `source_ip` is affordable: a hostname is not discarded,
+it moves to a field nothing decides on. Which is also the constraint — by rule 2 of
+the extension rules, a receiver must not read `metadata.rhost` for an
+authorization decision. It is audit context. If a peer ever needs a hostname to
+decide something, that is a new field in this document at a new version, not a
+reinterpretation of this one.
 
 ### `authenticate`
 
@@ -333,6 +373,21 @@ treat the reply as a failure, which for all of these is the right answer:
 | `SESSION_EXPIRED` | broker | the session or device code ran out of time |
 | `SESSION_NOT_ACTIVE` | broker | a session verb was used on a session that is not authorized |
 | `AUTHENTICATION_FAILED`, `SESSION_CHECK_FAILED`, `SESSION_REFRESH_FAILED`, `SESSION_REVOCATION_FAILED` | broker | the verb's handler returned an internal error; details are in the broker's log, deliberately not on the wire |
+| `RESPONSE_TOO_LARGE` | broker | the reply for this request did not fit the reply cap and was replaced by this one. Terminal |
+
+`RESPONSE_TOO_LARGE` is registered here because `oidc-pam` sends it (`oidc-pam#162`:
+an 8 KiB client buffer against a reply whose QR art was serialized twice refused
+every login on the host, with nothing in the log but "failed to parse broker
+response"), and by rule 3 above a code a second implementation reads is contract
+rather than dialect. A client that gets it learns the difference between "the broker
+sent something I could not parse" and "the broker had something to say and it did
+not fit" — which is the whole value of substituting it.
+
+Whether a version-1 broker is *obliged* to substitute it, rather than writing an
+oversized reply and leaving the client to refuse, is not settled here: that is a
+requirement on brokers, this one does not yet meet it, and specifying it is
+[#48](https://github.com/scttfrdmn/oauth2-pam/issues/48). Sending it is permitted
+today; relying on receiving it is not.
 
 ## What this contract deliberately does not do
 
@@ -393,6 +448,16 @@ A **broker**:
    it.
 7. Never puts internal error detail on the wire. `error_code` is a category;
    the detail belongs in the broker's log.
+8. Accepts a zoned IPv6 `source_ip` — a validator that rejects `fe80::1%eth0`
+   refuses a login this contract sized a field for.
+9. Never satisfies a network requirement from an absent `source_ip`. Absent is
+   `unknown`, and what `unknown` does is a decision the broker must have made
+   before it is asked, not one a validator makes for it by returning false.
+
+Both ends: **an extension field is never load-bearing for the grant.** Not a
+separate item because it is not a separate test — it is the property the other
+items are protecting, and the way to check it is to delete the field and see
+whether the decision changes.
 
 ## Testing this contract
 

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -39,6 +39,16 @@ func TestValidateRequest(t *testing.T) {
 		{"session id at the limit", Request{Type: "check_session", SessionID: strings.Repeat("a", 128)}, ""},
 		{"session id over the limit", Request{Type: "check_session", SessionID: strings.Repeat("a", 129)}, "session_id too long"},
 		{"source ip over the limit", Request{Type: "authenticate", UserID: "alice", SourceIP: strings.Repeat("a", 46)}, "source_ip too long"},
+		// docs/wire-protocol.md requires a receiver to accept a zoned IPv6
+		// literal, and it is the one address shape a well-meaning validator
+		// breaks: net.ParseIP fails on a zone, as does inet_pton. This request is
+		// accepted because source_ip is length-bounded audit context here and
+		// nothing parses it — pinned so that stays a decision rather than a
+		// detail someone "fixes" into refusing link-local logins.
+		{"zoned IPv6 source ip", Request{Type: "authenticate", UserID: "alice", SourceIP: "fe80::1%eth0"}, ""},
+		// A console login has no source address at all. Absent means "origin
+		// unknown", never a malformed request.
+		{"absent source ip", Request{Type: "authenticate", UserID: "alice", SourceIP: ""}, ""},
 		{"target host over the limit", Request{Type: "authenticate", UserID: "alice", TargetHost: strings.Repeat("a", 254)}, "target_host too long"},
 
 		{"login type ssh", Request{Type: "authenticate", UserID: "alice", LoginType: "ssh"}, ""},


### PR DESCRIPTION
Documentation and one test. No runtime behaviour changes.

Version 1 ships as a normative contract in v0.3.0, and oidc-pam is being asked to conform to it right now (oidc-pam#179). These are two places where it was silent, both found by an implementation hitting the silence rather than by reading:

**An absent `source_ip` had no defined meaning to a broker enforcing a network requirement.** Both readings a broker reaches for on its own are silent failures — absent-as-not-private refuses every console login and reports an *unknown* origin as a public one; absent-as-satisfied makes the requirement bypassable by omitting one optional field. oidc-pam#169 was the first: `net.ParseIP("")` said no, so every login on a host with the requirement on was refused. Version 1 now says absent is `unknown`, a third answer, and that `unknown` never satisfies a network requirement — while leaving what `unknown` *does* to the broker, because that is policy. The point is that a broker must have decided before it is asked rather than arriving at an answer inside a validator.

**A zoned IPv6 literal must be accepted.** `fe80::1%eth0` fits the 45-byte bound the field always carried, and it is the one address shape a well-meaning validator breaks: `net.ParseIP` and `inet_pton` both fail on a zone. This broker length-bounds `source_ip` and parses nothing, so it already conformed — `TestValidateRequest` now pins that, because "we don't parse it" is exactly the kind of thing someone helpfully undoes.

**`RESPONSE_TOO_LARGE` is registered.** oidc-pam sends it (oidc-pam#162), and version 1's own rule says a code a second implementation reads has stopped being dialect.

### What this deliberately does not do

`RESPONSE_TOO_LARGE` is registered as *permitted to send*, not as *guaranteed to arrive*. Whether a v1 broker must substitute a parseable error rather than writing an oversized reply is a requirement on brokers that **this broker does not currently meet** — it has no outbound reply cap at all, only the 64 KiB inbound one. Both the spec and #48 say so, rather than publishing a guarantee the reference implementation doesn't honour. That, the question of whether 16 KiB is normative or advisory, and whether `groups` needs a bound, stay open on #48 for v0.4.0, where they can come with the code and the tests.

Unblocks nothing; sequenced before the v0.3.0 cut so that version 1 is published without these holes.

Closes #52
Refs #48