### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-14
+
+0.2.0 made authentication work. This release is about being able to trust it:
+repeated adversarial review, of the design and of the security of the
+implementation, and the findings each round produced — plus the contract the whole
+thing rests on, written down.
+
+The protocol between broker and module is now a **specified, versioned contract**
+that this repository owns ([`docs/wire-protocol.md`](docs/wire-protocol.md),
+version 1), with `protocol_version` on the wire in both directions and a
+conformance checklist whose every item is something an implementation in this
+family has actually got wrong. Two of the defects fixed here were exploitable as
+shipped, and they need different things from an attacker. `refresh_session`
+extended sessions that had already expired and answered `authorized` — reachable
+only by something that can reach the broker socket, which in this project's
+packaging means root, a boundary this release also stops merely implying and starts
+stating. The other needs no local access at all: the provider chose the strings a
+root process drew on a terminal before anyone had authenticated, so a compromised
+GitHub Enterprise deployment could draw a fake password prompt on every host
+configured against it.
+
+**Upgrade notes.** An unknown key in `broker.yaml` is now a startup error rather
+than a silently ignored line, so a config with a typo that used to "work" will
+refuse to start — deliberately, because six fields in 0.2.0 were parsed and
+ignored. `audit.outputs[].url` and `.headers` are gone. The documented PAM stack
+changes to `auth required` after the distribution's own module, the module's
+`timeout=` default drops from 300s to 90s to fit inside sshd's `LoginGraceTime`,
+and the minimum Go version is 1.25.
+
 ### Added
 
 - **Version 1 says what an absent `source_ip` means, and that a zoned IPv6

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/scttfrdmn/oauth2-pam/actions/workflows/ci.yml/badge.svg)](https://github.com/scttfrdmn/oauth2-pam/actions/workflows/ci.yml)
 [![Security](https://github.com/scttfrdmn/oauth2-pam/actions/workflows/security.yml/badge.svg)](https://github.com/scttfrdmn/oauth2-pam/actions/workflows/security.yml)
-[![version](https://img.shields.io/badge/version-0.2.0-blue)](https://github.com/scttfrdmn/oauth2-pam/releases)
+[![version](https://img.shields.io/badge/version-0.3.0-blue)](https://github.com/scttfrdmn/oauth2-pam/releases)
 
 A Linux PAM module that authenticates users via OAuth2 Device Flow, with GitHub as the primary provider. Users authenticate by visiting a URL on their phone and approving the request — no passwords, no SSH key distribution.
 


### PR DESCRIPTION
The release commit: version badge `0.2.0` → `0.3.0`, `[Unreleased]` rolled into `[0.3.0] - 2026-08-14` with a lead paragraph and upgrade notes, and a fresh empty `[Unreleased]` left behind. No code.

Normally `scripts/release.sh` does this and pushes straight to `main`. `main` now requires a pull request, and taking the admin bypass would skip the checks that protection exists to run — so the script's edits are reproduced here and the tag goes on `main` after this merges. The Release workflow re-verifies that the tag, the badge and the CHANGELOG all agree, so the same thing is checked either way.

### What's in v0.3.0

- **The wire protocol is a specified, versioned contract this repo owns** — `docs/wire-protocol.md` version 1, `protocol_version` on the wire both directions, a conformance checklist, and the two silences closed in #53.
- **Two defects that were exploitable as shipped:** `refresh_session` extending an already-expired session and answering `authorized` (#41), and provider-chosen strings reaching a pre-auth terminal (#45). They need different things from an attacker, and the notes say which.
- The rest of the security review round: #42 (unbounded session limiter), #43 (`max_token_age` never enforced), #44 (socket trust boundary), #46 (enrollment validation).
- Earlier rounds: mapper UID floor and system-account denylist, C bridge hardening with its own unit tests, mutation checks on both suites as CI jobs, secret-file/systemd-credential loading, provider interface, strict config decoding, Go 1.25.

### Deliberately not in it

#17 (share the bridge with oidc-pam) moved to v0.4.0 — everything it needs from this repo is done, and the rest waits on oidc-pam#146 and #179. #48's remaining parts moved to v0.4.0 too: whether a broker *must* substitute a parseable reply when its own reply is oversized is a requirement this broker does not yet meet, and it should be specified in the same change that implements it rather than one release ahead of it.

Closes #47