### PR TITLE
Fix a fail-closed-forever audit wedge and the last unsanitized terminal path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - name: C bridge tests
         run: sudo env NATIVE=1 test/cbridge/run.sh
 
-      # And the check on that check: reintroduce each of the six fixed defects in
+      # And the check on that check: reintroduce each fixed defect in turn in
       # a copy of the source and assert the suite fails. Without this, SECURITY.md
       # claiming the tests are mutation-verified is a claim about a run nobody can
       # see. Same sudo/NATIVE reasoning as above — the mutated suite has to be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ recommended stack omitted the `account` line that a whole round's work depends o
 Three of the five were found by reading a comment against the code it describes, which
 is now a habit worth keeping and, where possible, a check.
 
+A seventh round found one, and it is the counting error the previous six rounds were
+structurally unable to make: every one of them asked whether the mitigation was
+correct, and none asked how many callers were using it. `SanitizePromptValue` was
+written in round three for the pre-auth PAM terminal, is thoroughly tested, and had
+four call sites — all in `pkg/auth`. The fifth place a provider-chosen string reaches
+a terminal is `oauth2-pam-enroll`, which does not import `pkg/auth` and so inherited
+none of it. A test of a function cannot notice a caller that does not call it, and
+neither can a reviewer who starts from the function.
+
 **Upgrade notes.** `broker.yaml` must be mode 0600 regardless of where the client
 secret lives — the check used to apply only when the secret was inline, which left
 the file holding the token-encryption key unchecked in every deployment that did the
@@ -56,6 +65,22 @@ revocation; read the warning next to it first, because `account required
 oauth2_pam.so` on its own denies the publickey break-glass path.
 
 ### Fixed
+
+- **`oauth2-pam-enroll` drew the provider's `verification_uri` and `user_code` on a
+  root terminal without filtering them.** The broker sanitizes those two strings
+  before they reach a pre-auth tty, for a reason it states at length: with a GitHub
+  Enterprise `base_url` configured, that server picks both, so its operator picks what
+  every host configured against it draws on screen. `oauth2-pam-enroll` gets the same
+  two strings from the same `StartDeviceFlow` call and printed them with a bare `%s` —
+  it does not import `pkg/auth`, so it inherited nothing. The terminal here is worse,
+  not better: an operator runs this under `sudo`, so the escapes land on a root shell
+  moments after a real sudo password was typed into it, and because the command never
+  reads stdin, anything typed at a fake prompt is left in the tty queue for the
+  invoking shell to run as a command. Both values now go through
+  `SanitizePromptValue`, and the print is a function taking an `io.Writer` so that a
+  test can assert on what reaches the terminal — `runEnroll` needs a config, a real
+  local account and a reachable provider before it prints anything, which is how these
+  two lines came to be the last unfiltered path in the tree.
 
 - **The stalled-sink flag could still wedge fail-closed forever, and did so on CI one
   push after the round that thought it had fixed it.** An audit write runs on its own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,29 @@ oauth2_pam.so` on its own denies the publickey break-glass path.
 
 ### Fixed
 
+- **The stalled-sink flag could still wedge fail-closed forever, and did so on CI one
+  push after the round that thought it had fixed it.** An audit write runs on its own
+  goroutine with the deadline enforced by the caller, so two paths can observe the
+  same write and a compare-and-set on `settled` decides which one reports it. That CAS
+  orders the *report*; it does not order the two stores to the `stalled` flag. With the
+  deadline path descheduled between winning the CAS and storing `true`, the write's own
+  deferred `Store(false)` lands first — and the flag ends up set with nothing
+  outstanding. Nothing clears it after that, because a refused write returns without
+  spawning a goroutine, so every audit record for the life of the process is refused;
+  and since an access decision that cannot be recorded is refused, the broker grants no
+  logins at all while its sinks are perfectly healthy. Round five narrowed this window
+  and its comment argued it was closed. The argument was wrong in a way that a bool
+  cannot be made right: the deadline path cannot clear the flag, because the write is by
+  definition still running when it gives up, and the write cannot clear it either. So
+  the state is no longer a verdict about a write but a pointer to the write, carrying
+  its own completion signal, and `sinksStalled` asks it — recording a write that has
+  already finished is then harmless, and the invariant holds by construction rather
+  than by two stores landing in the right order. The test that caught this needed about
+  forty runs to do it, because it sampled the flag once at an instant when a returned
+  write legitimately still holds `writeMu`; polled to a deadline instead, it fails on
+  the first run against the old mechanism.
+  ([#100](https://github.com/scttfrdmn/oauth2-pam/issues/100))
+
 - **The sink that reports a failed `fsync` was read as having written nothing, which
   is the one case the correction above exists for.** #91 computes "may the record have
   landed" by counting sinks whose `Write` returned nil. `fileOutput.Write` is a

--- a/Makefile
+++ b/Makefile
@@ -179,8 +179,8 @@ test-cbridge:
 ## Check that the C bridge tests would catch the defects they were written for
 ##
 ## A green suite proves the code does what the tests say; it does not prove the
-## tests would notice if it stopped. This reintroduces each of the six fixed
-## bridge defects in a copy of the source under $$TMPDIR and asserts the suite
+## tests would notice if it stopped. This reintroduces each fixed bridge defect
+## in turn in a copy of the source under $$TMPDIR and asserts the suite
 ## fails. An uncaught mutation means that regression test is decoration.
 test-cbridge-mutations:
 	@echo "Running C bridge mutation check..."

--- a/cmd/oauth2-pam-enroll/instructions_test.go
+++ b/cmd/oauth2-pam-enroll/instructions_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/scttfrdmn/oauth2-pam/pkg/provider"
+)
+
+// What this command draws on a root terminal — #102.
+//
+// The broker sanitizes verification_uri and user_code before they reach a pre-auth
+// tty (broker.go:386, and #45 for why). This command reaches a terminal with the
+// same two strings out of the same StartDeviceFlow return value, and until #102 it
+// printed them with a bare %s — the only place in the tree where provider bytes
+// got to a terminal unfiltered, and the terminal in question is already root.
+//
+// pkg/auth/sanitize_test.go tests the sanitizer. This tests the call site, which
+// is the half that was missing: a test of the function cannot notice a caller that
+// does not call it.
+
+// hostileFlow is what a malicious or compromised GitHub Enterprise returns. The
+// escapes are the ones that matter rather than an arbitrary sample: CSI 2J clears
+// the screen, CSI H homes the cursor, and OSC 0 ; ... ST followed by CSI 21 t is
+// the terminal answerback attack, which makes an xterm-family terminal type the
+// attacker's text into its own input queue. Because this command never reads
+// stdin, that text is left for the invoking root shell.
+func hostileFlow() *provider.DeviceFlow {
+	return &provider.DeviceFlow{
+		DeviceCode:      "notprinted",
+		UserCode:        "WDJB\x1b]0;rm -rf /\x07-MJHT",
+		DeviceURL:       "https://ghes.example/login/device\x1b[2J\x1b[H[sudo] password for admin: ",
+		ExpiresAt:       time.Now().Add(15 * time.Minute),
+		PollingInterval: 5,
+	}
+}
+
+func TestTheDeviceInstructionsCarryNoProviderChosenControlCharacters(t *testing.T) {
+	var out bytes.Buffer
+	printDeviceInstructions(&out, "alice", "github", hostileFlow())
+	got := out.String()
+
+	// Every rune the sanitizer's policy removes, checked here rather than trusting
+	// the policy: this asserts what reaches the terminal, not what the sanitizer
+	// says it does. Newline is the exception — the template's own newlines are the
+	// layout, and SanitizePromptValue removes newlines from the values.
+	for i, r := range got {
+		switch {
+		case r == '\n':
+		case r < 0x20, r == 0x7f, r >= 0x80 && r <= 0x9f, r == '\u2028', r == '\u2029':
+			t.Errorf("byte %d of the instructions is control character %#U; "+
+				"a provider that chooses this can clear an operator's root terminal and draw a "+
+				"fake sudo prompt on it", i, r)
+		}
+	}
+	if !utf8.ValidString(got) {
+		t.Error("the instructions are not valid UTF-8; a raw 0x9b is a CSI to a terminal reading bytes")
+	}
+}
+
+// TestTheDeviceInstructionsStillSayWhatToDo is the control. Removing every
+// character would pass the test above and leave the operator with nothing to act
+// on, and the sanitizer is deliberately lossy — so pin that the parts the operator
+// needs survive, and that the tampering is visible rather than silently repaired.
+func TestTheDeviceInstructionsStillSayWhatToDo(t *testing.T) {
+	var out bytes.Buffer
+	printDeviceInstructions(&out, "alice", "github", hostileFlow())
+	got := out.String()
+
+	for _, want := range []string{
+		`"alice"`,                           // who is being enrolled
+		"github",                            // against what
+		"https://ghes.example/login/device", // where to go, minus the escapes
+		"WDJB",                              // and the code to type there
+		"MJHT",
+		"control character(s) removed", // and that something was taken out
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the instructions do not contain %q; operator sees:\n%s", want, got)
+		}
+	}
+}
+
+// TestCleanDeviceInstructionsAreUnchanged: the github.com case, which is every
+// real deployment. A sanitizer that marked or mangled ordinary values would put a
+// "[!]" on every enrollment and train operators to ignore it.
+func TestCleanDeviceInstructionsAreUnchanged(t *testing.T) {
+	var out bytes.Buffer
+	printDeviceInstructions(&out, "alice", "github", &provider.DeviceFlow{
+		UserCode:  "WDJB-MJHT",
+		DeviceURL: "https://github.com/login/device",
+		ExpiresAt: time.Now().Add(15 * time.Minute),
+	})
+	got := out.String()
+
+	if !strings.Contains(got, "  Visit:      https://github.com/login/device\n") {
+		t.Errorf("the URL was altered on a clean value; operator sees:\n%s", got)
+	}
+	if !strings.Contains(got, "  User Code:  WDJB-MJHT\n") {
+		t.Errorf("the user code was altered on a clean value; operator sees:\n%s", got)
+	}
+	if strings.Contains(got, "[!]") {
+		t.Errorf("a clean device flow was reported as tampered with; operator sees:\n%s", got)
+	}
+}

--- a/cmd/oauth2-pam-enroll/main.go
+++ b/cmd/oauth2-pam-enroll/main.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"os/user"
@@ -23,6 +24,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
+	"github.com/scttfrdmn/oauth2-pam/pkg/auth"
 	"github.com/scttfrdmn/oauth2-pam/pkg/config"
 	"github.com/scttfrdmn/oauth2-pam/pkg/enrollment"
 	"github.com/scttfrdmn/oauth2-pam/pkg/mapper"
@@ -240,10 +242,7 @@ func runEnroll(localUser, providerName string, groups []string, enrollFile strin
 		return fmt.Errorf("start device flow: %w", err)
 	}
 
-	fmt.Printf("\nTo enroll %q, authorize this application at %s:\n\n", localUser, prov.Name())
-	fmt.Printf("  Visit:      %s\n", flow.DeviceURL)
-	fmt.Printf("  User Code:  %s\n\n", flow.UserCode)
-	fmt.Printf("Waiting for authorization (expires in %s)...\n", time.Until(flow.ExpiresAt).Round(time.Second))
+	printDeviceInstructions(os.Stdout, localUser, prov.Name(), flow)
 
 	token, err := pollUntilAuthorized(ctx, prov, flow)
 	if err != nil {
@@ -310,6 +309,39 @@ func runEnroll(localUser, providerName string, groups []string, enrollFile strin
 		fmt.Printf("Groups: %s\n", strings.Join(groups, ", "))
 	}
 	return nil
+}
+
+// printDeviceInstructions writes the "go here, type this" block for a started
+// device flow.
+//
+// The two provider-chosen strings are sanitized for the same reason the broker
+// sanitizes them at broker.go:386 — #102. For a configured GitHub Enterprise
+// base_url it is the operator of that server who picks verification_uri and
+// user_code, and printed raw they can home the cursor, clear the screen and draw
+// a convincing prompt. The terminal they would draw it on here is a root shell
+// that was very likely just given a sudo password, and because this command never
+// reads stdin, anything typed at a fake prompt is left in the tty queue for the
+// invoking shell to run.
+//
+// prov.Name() needs none of this: it is providers[].name out of a root-owned
+// config file, not something the provider said. localUser is printed with %q and
+// has already been through the mapper's name gate.
+//
+// A function taking an io.Writer rather than four Printf calls in runEnroll,
+// because runEnroll needs a config, a real local account and a reachable provider
+// to reach its first print — which is how these two lines came to be the only
+// place in the tree where provider bytes reached a terminal unfiltered.
+// The write errors are discarded, which errcheck exempts for Printf and not for
+// Fprintf. There is nothing to do with a stdout that will not take bytes: the
+// operator cannot be told, since telling them is the write that just failed, and
+// failing the enrollment over it would refuse a device flow the provider has
+// already started.
+func printDeviceInstructions(w io.Writer, localUser, providerName string, flow *provider.DeviceFlow) {
+	_, _ = fmt.Fprintf(w, "\nTo enroll %q, authorize this application at %s:\n\n", localUser, providerName)
+	_, _ = fmt.Fprintf(w, "  Visit:      %s\n", auth.SanitizePromptValue(flow.DeviceURL))
+	_, _ = fmt.Fprintf(w, "  User Code:  %s\n\n", auth.SanitizePromptValue(flow.UserCode))
+	_, _ = fmt.Fprintf(w, "Waiting for authorization (expires in %s)...\n",
+		time.Until(flow.ExpiresAt).Round(time.Second))
 }
 
 // selectProviderConfig picks the providers[] entry to enroll against: the named

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -533,12 +533,16 @@ func (c *Config) Validate() error {
 	// built in code rather than loaded from a file gets the floor rather than an
 	// error.
 	//
-	// A negative value turns the floor off entirely — pkg/mapper's check is
-	// `minUID >= 0 && uid < minUID` — leaving only the system-account name
+	// A negative value would mean "no floor", leaving only the system-account name
 	// denylist, which on an LDAP/SSSD host a broker built without cgo cannot even
 	// resolve names against. That is not a setting worth having: a site with real
 	// accounts below 1000 says so by naming the lowest UID it means to allow, and
 	// nothing else needs the floor gone.
+	//
+	// Two independent guards, so neither has to be the only one: this refusal, and
+	// mapper.New clamping a non-positive value to the default. Which is why
+	// mapper's own check is an unconditional `uid < c.minUID` — by the time it runs,
+	// minUID cannot be negative by either route.
 	if c.Mapper.MinUID < 0 {
 		return fmt.Errorf("mapper.min_uid must not be negative (got %d): a negative value disables "+
 			"the UID floor for every tier; to allow accounts below 1000, set the lowest UID you "+

--- a/pkg/security/audit.go
+++ b/pkg/security/audit.go
@@ -54,10 +54,11 @@ type AuditLogger struct {
 	// caller's goroutine (see criticalAuditEvents) while the dispatcher may be
 	// writing a queued one, and Stop closes the sinks underneath both.
 	writeMu sync.Mutex
-	// stalled records that a write overran auditWriteTimeout and has not come back.
-	// While it is set, writeEvent refuses immediately rather than queueing behind a
-	// mutex held by a goroutine stuck in an fsync. See writeEvent.
-	stalled atomic.Bool
+	// stalledOn names the write that overran auditWriteTimeout and has not come
+	// back, or is nil if none has. While it is set and that write is still running,
+	// writeEvent refuses immediately rather than queueing behind a mutex held by a
+	// goroutine stuck in an fsync. See sinksStalled and writeEvent.
+	stalledOn atomic.Pointer[writeToken]
 	// testWriteTimeout overrides auditWriteTimeout. Only tests set it — a stalled
 	// sink is otherwise untestable in reasonable time, since the honest version of
 	// the test has to wait out the deadline.
@@ -400,9 +401,58 @@ func RecordMayHaveLanded(err error) bool {
 // to clear it, the flag stayed set and every later record was refused for the life
 // of the process. Fail-closed forever is still a broker that grants no logins.
 //
+// Winning settled decides who reports, and that is all it decides: it does not
+// order the two stores to stalled, which is how the paragraph above described a
+// bug it had only narrowed rather than closed. The state is no longer a flag at
+// all — see sinksStalled for why a flag could not be made correct here.
+//
 // A stalled sink still blocks Stop, which takes writeMu to close the outputs. That
 // is not new — a caller stuck in Sync held the same mutex before this change — and
 // it is a shutdown that hangs rather than a login that is silently unrecorded.
+// writeToken is one audit write's completion signal. The goroutine performing the
+// write closes finished when it is back, whatever the outcome was and whoever
+// reported it.
+type writeToken struct{ finished chan struct{} }
+
+// sinksStalled reports whether a write has overrun its deadline and not yet come
+// back, which is the condition for refusing a record rather than queueing behind a
+// mutex nobody is going to release soon.
+//
+// The state is a pointer to the overrunning write's own completion signal rather
+// than a bool, because a bool has to be cleared by somebody and neither candidate
+// can do it correctly. The deadline path cannot: the write is by definition still
+// running when it gives up. The write that eventually returns cannot either, and
+// this is the part two review rounds got wrong — its store and the deadline path's
+// store are unordered, so it could clear the flag microseconds before the deadline
+// path set it, leaving the flag set with nothing outstanding and no goroutine left
+// to clear it, because a refused write spawns none. Every record after that was
+// refused for the life of the process: a broker that grants no logins at all, out
+// of one write that was a few microseconds late. Round five narrowed that window
+// and called it closed; it took about forty runs of
+// TestAWriteReturningAsItsDeadlineFiresDoesNotWedgeTheStalledFlag to reappear, and
+// it reappeared on a CI runner rather than here.
+//
+// Asking the write itself has no such window. Recording a write that has already
+// finished is harmless, because the recorded thing carries its own answer: the next
+// caller looks, sees it is back, and retires it. The invariant the test states —
+// with no write outstanding, nothing is stalled — holds by construction rather than
+// by two stores landing in the right order.
+func (al *AuditLogger) sinksStalled() bool {
+	tok := al.stalledOn.Load()
+	if tok == nil {
+		return false
+	}
+	select {
+	case <-tok.finished:
+		// Back. Retire it, but only if nothing newer has taken its place since the
+		// load — otherwise this would clear a genuinely stalled write's record.
+		al.stalledOn.CompareAndSwap(tok, nil)
+		return false
+	default:
+		return true
+	}
+}
+
 func (al *AuditLogger) writeEvent(event AuditEvent) error {
 	data, err := json.Marshal(event)
 	if err != nil {
@@ -410,7 +460,7 @@ func (al *AuditLogger) writeEvent(event AuditEvent) error {
 		return fmt.Errorf("marshal audit event %s: %w", event.EventType, err)
 	}
 
-	if al.stalled.Load() {
+	if al.sinksStalled() {
 		log.Error().Str("event_type", event.EventType).
 			Msg("Audit sinks are not draining; refusing the record rather than waiting on them")
 		return &WriteError{
@@ -423,14 +473,16 @@ func (al *AuditLogger) writeEvent(event AuditEvent) error {
 	// settled decides which of the two paths below owns this write's outcome: the
 	// goroutine that returns, or the deadline that gives up on it. Exactly one.
 	var settled atomic.Bool
+	tok := &writeToken{finished: make(chan struct{})}
 	go func() {
 		al.writeMu.Lock()
 		defer func() {
-			// settled before stalled, and both before the unlock: claiming the outcome
-			// first is what stops the deadline path from setting a flag that this
-			// goroutine has already gone past clearing.
+			// The only thing this goroutine has to say about the stalled state: it is
+			// back. Whether anybody had given up on it in the meantime is not its
+			// business, and not asking is what removes the ordering problem — see
+			// sinksStalled.
+			close(tok.finished)
 			settled.Store(true)
-			al.stalled.Store(false)
 			al.writeMu.Unlock()
 		}()
 
@@ -475,7 +527,10 @@ func (al *AuditLogger) writeEvent(event AuditEvent) error {
 			// one, and the send on done has either happened or is about to.
 			return <-done
 		}
-		al.stalled.Store(true)
+		// Recording the write rather than a verdict about it. Doing this for a write
+		// that has in fact just finished is harmless: the next caller asks the write
+		// whether it is back, and it says yes.
+		al.stalledOn.Store(tok)
 		log.Error().Str("event_type", event.EventType).Dur("timeout", al.writeTimeout()).
 			Msg("Audit write exceeded its deadline; treating the record as unwritten")
 		return &WriteError{

--- a/pkg/security/audit_landing_test.go
+++ b/pkg/security/audit_landing_test.go
@@ -266,15 +266,16 @@ func (o *boundaryOutput) setDelay(d time.Duration) {
 	o.delay = d
 }
 
-func (o *boundaryOutput) quiet() bool {
+func (o *boundaryOutput) quiet() bool { return o.inFlightNow() == 0 }
+
+func (o *boundaryOutput) inFlightNow() int {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	return o.inFlight == 0
+	return o.inFlight
 }
 
 // TestAWriteReturningAsItsDeadlineFiresDoesNotWedgeTheStalledFlag.
 //
-// The stalled flag is set by the deadline and cleared by the write that overran it.
 // A write that returns in the same instant its deadline fires used to be declared
 // stalled *after* it had cleared the flag — and a refused write spawns no goroutine
 // to clear it, so the flag stayed set and every record after it was refused for the
@@ -282,8 +283,18 @@ func (o *boundaryOutput) quiet() bool {
 // out of one write that was a few microseconds late.
 //
 // The interleaving cannot be forced from outside, so this aims a few hundred writes
-// at the boundary and then asserts the invariant on a quiescent logger, where the
-// answer is not a matter of timing: with no write outstanding, nothing is stalled.
+// at the boundary and then asserts that the stalled state goes away by itself. What
+// it must distinguish is a state that is briefly true from one that is permanently
+// true, and the difference is not visible at any single instant: a write that has
+// returned from the sink still holds writeMu until its deferred teardown runs, and
+// through that window — nanoseconds, and there whatever the mechanism — the logger is
+// correctly still busy with it.
+//
+// So the probe is the logger's own predicate polled to a deadline, not the sink's
+// in-flight count read once. Reading the sink was the earlier version of this test,
+// and it was wrong in the direction that matters: it made a real fix look broken
+// while the interleaving it was written for went on being possible for 40 runs at a
+// time. The wedge this guards against does not clear in two seconds, or ever.
 func TestAWriteReturningAsItsDeadlineFiresDoesNotWedgeTheStalledFlag(t *testing.T) {
 	const timeout = 2 * time.Millisecond
 
@@ -301,17 +312,18 @@ func TestAWriteReturningAsItsDeadlineFiresDoesNotWedgeTheStalledFlag(t *testing.
 
 	sink.setDelay(0)
 	deadline := time.Now().Add(2 * time.Second)
-	for !sink.quiet() {
+	for al.sinksStalled() {
 		if time.Now().After(deadline) {
-			t.Fatal("a write was still outstanding two seconds after the last one was issued")
+			t.Fatal("the sinks are healthy and idle and the logger still considers them stalled, " +
+				"two seconds after the last write was issued; every later record will be " +
+				"refused for the life of the process")
 		}
 		time.Sleep(time.Millisecond)
 	}
-
-	if al.stalled.Load() {
-		t.Error("no write is outstanding and the logger still considers its sinks stalled; " +
-			"every later record will be refused for the life of the process")
+	if !sink.quiet() {
+		t.Errorf("the logger reports its sinks unstalled while %d writes are still in flight", sink.inFlightNow())
 	}
+
 	if err := al.LogAuthEventErr(criticalEvent()); err != nil {
 		t.Errorf("a record offered to an idle, healthy sink was refused: %v", err)
 	}

--- a/pkg/security/audit_stall_test.go
+++ b/pkg/security/audit_stall_test.go
@@ -152,8 +152,9 @@ func TestOnceTheSinksHaveStalledLaterRecordsFailImmediately(t *testing.T) {
 }
 
 // TestASinkThatComesBackClearsTheStall is the other half: a mount that recovers
-// must not leave the audit trail permanently refused. The flag is cleared by
-// whichever write eventually returns, so the next record is written normally.
+// must not leave the audit trail permanently refused. The stalled state names the
+// write that overran, so it stops being true as soon as that write comes back and
+// the next record is written normally.
 func TestASinkThatComesBackClearsTheStall(t *testing.T) {
 	al, sink := stalledLogger(t, 100*time.Millisecond)
 
@@ -164,10 +165,10 @@ func TestASinkThatComesBackClearsTheStall(t *testing.T) {
 	sink.unblock()
 
 	deadline := time.Now().Add(5 * time.Second)
-	for al.stalled.Load() && time.Now().Before(deadline) {
+	for al.sinksStalled() && time.Now().Before(deadline) {
 		time.Sleep(5 * time.Millisecond)
 	}
-	if al.stalled.Load() {
+	if al.sinksStalled() {
 		t.Fatal("the sink returned but the logger is still refusing records")
 	}
 


### PR DESCRIPTION
Two fixes found after round six landed.

## The stalled-sink flag could wedge fail-closed forever (#100)

CI went red on the macOS runner one push after `d006fd7`, in round five's own test. Not a flake — a real defect in round five's fix.

An audit write runs on its own goroutine with the deadline enforced by the caller, so two paths can observe the same write, and a compare-and-set on `settled` decides which reports it. That CAS orders the *report*. It does not order the two stores to the `stalled` flag. With the deadline path descheduled between winning the CAS and storing `true`, the write's own deferred `Store(false)` lands first, and the flag ends up set with nothing outstanding — and nothing clears it, because a refused write returns without spawning a goroutine.

Every audit record is then refused for the life of the process. Since an access decision that cannot be recorded is a refused login, the broker grants no logins at all while its sinks are perfectly healthy.

A bool cannot be made right here: the deadline path cannot clear it (the write is by definition still running when it gives up) and the write cannot clear it either (its store is unordered against the deadline's). So the state is no longer a verdict about a write but an `atomic.Pointer` to the write, carrying its own completion signal, and `sinksStalled()` asks it.

The test's probe was also wrong in the direction that matters — it read the sink's in-flight count once, which cannot distinguish "briefly busy" from "permanently wedged", the entire distinction. It now polls the logger's own predicate to a deadline. Against the old mechanism the rewritten test fails deterministically in one run at 2.04s instead of one run in forty.

## oauth2-pam-enroll drew provider bytes on a root terminal unfiltered (#102)

Round seven. The broker sanitizes `verification_uri` and `user_code` before they reach a pre-auth tty; `oauth2-pam-enroll` gets the same two strings from the same `StartDeviceFlow` call, does not import `pkg/auth`, and printed them with a bare `%s`. The terminal here is a root shell under `sudo`, moments after a real sudo password was typed into it — and because the command never reads stdin, anything typed at a fake prompt is left in the tty queue for the invoking shell to run.

Both values now go through `SanitizePromptValue`, and the print moved behind an `io.Writer` so a test can assert on the bytes. `runEnroll` needs a config, a real local account and a reachable provider before it prints anything, which is how these two lines stayed untested and therefore unfiltered.

Plus two comments that had stopped describing the code, both stale in the safe direction: `config.go` on the mapper's UID-floor check, and the Makefile/ci.yml on the C mutation harness having "six" cases when it has 26.

## Verification

- 800 consecutive runs of the previously-flaky test, clean
- `go test -race ./...` full tree, macOS and Linux
- `make verify-linux`: build, vet, race, golangci-lint 0 issues, `build-pam`, six exported entry points and nothing else, 226 C checks
- both fixes mutation-checked — restore the old code and the tests fail

Closes #100
Closes #102