### PR TITLE
Round 8: bound the audit record, unify the control-character policy, check the audit file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ a terminal is `oauth2-pam-enroll`, which does not import `pkg/auth` and so inher
 none of it. A test of a function cannot notice a caller that does not call it, and
 neither can a reviewer who starts from the function.
 
+An eighth round found six, and the two that matter share a shape the previous seven
+did not look for: a protection that exists on one path and not on the path beside it,
+where nothing in either place says the other exists. The prompt sanitizer had been
+hardened over three rounds to strip C1 as well as C0, because U+009B *is* CSI to a
+terminal decoding UTF-8; the reply filter twenty lines away kept its own narrower
+rule, and its test asserted that rule rather than the policy — restating the
+implementation's own predicate, so it could not have failed. The audit record had
+every field bounded on the way to the terminal and none of them bounded on the way to
+the audit file. The other three are documentation read against the code, which round
+six made a habit and this round made a test.
+
 **Upgrade notes.** `broker.yaml` must be mode 0600 regardless of where the client
 secret lives — the check used to apply only when the secret was inline, which left
 the file holding the token-encryption key unchecked in every deployment that did the
@@ -54,7 +65,7 @@ right thing with its secret. A deployment relying on the old behaviour will refu
 start until it is chmodded; the error names the file and the command. A negative
 `mapper.min_uid` is also now rejected rather than silently disabling the UID floor.
 
-Two more from the sixth round. The **directory holding `enrollments.json`** must not be
+Two more from the sixth round. The **directory holding `enrolled-users.yaml`** must not be
 writable by anyone but its owner unless it is sticky; `/etc/oauth2-pam` at 0750 root
 already satisfies this, but a deployment that put the file somewhere group-writable
 will now fail both `Load` and `Save` with an error naming the directory and
@@ -64,7 +75,131 @@ session or a deleted enrollment is not caught at login. Add it before relying on
 revocation; read the warning next to it first, because `account required
 oauth2_pam.so` on its own denies the publickey break-glass path.
 
+Three more from the eighth round, all startup errors rather than silent changes.
+`audit.outputs[].path` **must now be absolute** (under systemd the working directory
+is `/`, so a relative path named a file nobody meant), and the file and the directory
+holding it are checked the way the client secret and the enrollment file already were:
+the open refuses a symlink, the target must be a regular file, and neither it nor its
+directory may be writable by group or other. Group *read* stays allowed, so `0640`
+with an operators group is fine. And a malformed `security.token_encryption_key` is
+now rejected **even when `secure_token_storage: false`**, where it used to be exempt
+and then failed on the day storage was turned back on.
+
 ### Fixed
+
+- **The audit record was bounded on the way to the terminal and unbounded on the way
+  to the audit file.** Every provider-chosen string that reaches a pre-auth tty has a
+  byte cap and a filter; the same strings — provider login, email, mapped local user,
+  the group list, the error message a provider wrote — reached `LogAuthEventErr` at
+  whatever length they arrived, and from there a JSON line in `/var/log`, journald, and
+  `oauth2-pam-admin`'s console. An identity with a megabyte of groups is a megabyte per
+  login attempt, unauthenticated, from anything that can reach the socket, in the one
+  file the fail-closed rule says a login cannot proceed without: fill the filesystem
+  and the broker grants no logins at all. Records are now bounded on the way in —
+  1 KiB per string, 256 bytes per group name, 128 groups, 32 metadata keys, 64 KiB for
+  the record — with truncation marked in an `audit_truncated` field rather than done
+  silently, because a trail that quietly shortens a group name is a trail that lies
+  about who was in what. Truncation is at a rune boundary, so the record stays valid
+  UTF-8. A record that still cannot be bounded is replaced by a minimal one naming the
+  event, the decision and the account: the fail-closed rule means the alternative to a
+  degraded record is a refused login.
+  ([#104](https://github.com/scttfrdmn/oauth2-pam/issues/104))
+
+- **The reply filter kept its own narrower control-character rule, and its test could
+  not have caught it.** `boundedReplyField` stripped C0 and DEL; the prompt sanitizer
+  three rounds of hardening older also strips C1 (U+0080–U+009F), U+2028 and U+2029,
+  because `encoding/json` does not escape U+009B and U+009B *is* CSI to a terminal
+  decoding UTF-8. So a provider-chosen group name or email carrying a bare C1 was
+  filtered for the prompt and forwarded intact to the audit file, journald, and the
+  admin console. The test that was meant to hold that line asserted
+  `r < 0x20 || r == 0x7f` — the filter's own former condition, restated — over input
+  containing no C1 at all, which is a test structurally incapable of noticing what the
+  filter passed. `boundedReplyField` now calls the shared `isDisallowedInPrompt`, so
+  there is one policy in one place, and the test calls the shared
+  `assertNoDisallowedRunes`, which additionally requires the result to be valid UTF-8
+  and so closes the raw-`0x9b` case where a lone byte ranges as U+FFFD. A second test
+  walks an authorized reply by reflection and asserts on every string in it, so a field
+  added later is covered without anyone remembering to add it here.
+  ([#105](https://github.com/scttfrdmn/oauth2-pam/issues/105))
+
+- **The audit file was opened with no check on what it was or who could write it.** The
+  client secret's file, the mapper script and the enrollment file each refuse a
+  symlink, require a regular file, and require that neither the file nor its directory
+  be writable by anyone but the owner. The audit sink — the one file the fail-closed
+  rule refuses logins to protect — had none of it, and `path` was not even required to
+  be absolute. The symlink case is the one that matters: point the path at `/dev/null`
+  and every write succeeds, so "the record was written" is satisfied by a sink that
+  keeps nothing, every login is granted, and the trail is empty. That is the single
+  audit failure nothing downstream can detect, because every mechanism built to detect
+  one is watching for an error. `openAuditFile` now checks the directory *before* the
+  `O_CREAT` open (this is the tree's only creating open, so checking afterwards means
+  creating a file in a directory the process has just decided it does not trust), opens
+  with `O_NOFOLLOW`, and requires a regular file whose mode and owner it verifies from
+  the descriptor. The mask is write-only, 0o022, not the secret file's 0o077: a
+  group-readable trail at 0640 is a deliberate arrangement, and refusing it would
+  refuse every login on the host, which is a worse answer to a disclosure than the
+  disclosure. `O_NONBLOCK` is part of the fix rather than an incidental flag — an
+  `O_WRONLY` open of a FIFO with no reader blocks forever, so without it the
+  regular-file check is unreachable on exactly the path it exists to refuse, and the
+  test for it hangs the suite instead of failing.
+  ([#106](https://github.com/scttfrdmn/oauth2-pam/issues/106))
+
+- **The README named the wrong config key for tier 0, so following it produced a
+  broker that ignored every enrolled user.** Enrollment is switched on by
+  `mapper.enrollment_enabled`; the README gave `mapper.enrollment_file`, which only
+  says where the file is. An operator following it got "at least one tier must be
+  configured", added a rule to get past that, and ended with a broker where tier 0 was
+  never consulted while `oauth2-pam-enroll` reported success. The structural reason it
+  lasted is that `configs/example.yaml` is loaded and validated by a test and the prose
+  is not, so a new test takes the documentation's word for it: every dotted key in
+  backticks under a real config section, across `README.md`, `SECURITY.md` and
+  `docs/*.md`, must resolve to a real `mapstructure` tag, with a control test that
+  fails if the scan stops finding keys. It cannot check that a key means what the prose
+  says. It checks the thing that keeps being wrong: whether the key exists.
+  ([#107](https://github.com/scttfrdmn/oauth2-pam/issues/107))
+
+- **`configs/example.yaml` named the wrong error code for a full auth queue.**
+  `max_concurrent_auths` refuses with `AUTH_LIMIT_REACHED`, not `RATE_LIMITED`, and the
+  two are deliberately different answers: `RATE_LIMITED` comes from
+  `max_requests_per_minute` and means "retry", while `AUTH_LIMIT_REACHED` means the
+  capacity is held by other logins, is terminal for the attempt, and maps to a
+  different PAM result. A client keying on the documented name retries a refusal that
+  will not clear. No test catches this one and the comment says so — the wrong name is
+  itself a real constant, so nothing mechanical can tell which of the two the sentence
+  meant.
+  ([#108](https://github.com/scttfrdmn/oauth2-pam/issues/108))
+
+- **A cluster of documentation claims that were false against the code, several of them
+  in `SECURITY.md`, whose entire purpose is saying what is and is not verified.** Two
+  understated the project, which in that document is its own defect: it said no scanner
+  analyzed the C (the CodeQL job is a `go` + `c-cpp` matrix that compiles the bridge
+  under the extractor), and the README said nothing checked the directory around the
+  client-secret file (`checkPerms` ends by checking exactly that). Three overstated it:
+  a CodeQL finding does not fail the run and never did — there is no `fail-on` and no
+  threshold, so alerts land in the Security tab and the job stays green, which leaves
+  `govulncheck` and `dependency-review` as the only two tools whose "fails the run" is
+  backed by something in the file; the enrollment file's rule is write-only 0o022, not
+  the secret file's "0600 or tighter", so a 0644 enrollment file loads; and CI runs on
+  pushes to `main` plus pull requests, not "every push". Tokens are AES-GCM, but
+  AES-128 or AES-192 if a raw 16- or 24-byte key is configured, where both documents
+  said 256 unconditionally. The C bridge mutation count was six; it is 25 — so
+  `test/cbridge/mutations.sh` now counts its own `expect fail` cases and fails if the
+  total is not the documented one, which is the only one of these that can drift again
+  silently. Also corrected: the audit `events` list does not apply to the four
+  access-decision events (documented as "everything else is dropped", which is safer
+  than stated and the opposite of what an operator editing it expects), `local_user`
+  accepts the `{login}` spelling as well as `{{ .Login }}`, the secret file may be
+  owned by root *or* the broker's uid, the PAM module directory is asked of `dpkg`
+  where there is one and guessed from a fixed list elsewhere, and
+  `scripts/install-release.sh` claimed an unset encryption key left tokens in the clear
+  when the broker falls back to a per-process key. Two dead-code observations from the
+  same round are closed with it: `Encryption.Destroy` had no caller outside its own
+  test despite documenting "call it at shutdown", so `TokenManager.Stop` now calls it;
+  and `enrollment.Unvalidated`, exported so that callers choosing to skip validation
+  could be grepped for, has stayed at zero outside this package's tests and is now
+  unexported, since an exported sentinel with no callers is an invitation to a first
+  one.
+  ([#109](https://github.com/scttfrdmn/oauth2-pam/issues/109))
 
 - **`oauth2-pam-enroll` drew the provider's `verification_uri` and `user_code` on a
   root terminal without filtering them.** The broker sanitizes those two strings
@@ -127,7 +262,7 @@ oauth2_pam.so` on its own denies the publickey break-glass path.
 
 - **The enrollment file's permission check could be rolled back by anyone who could
   write its directory.** `checkPerms` asserts mode 0600 and root ownership on
-  `enrollments.json`, neither of which can be forged — but the *name* can be reused.
+  `enrolled-users.yaml`, neither of which can be forged — but the *name* can be reused.
   Given write access to the parent directory, an attacker renames the current file
   away and puts back an earlier root-owned 0600 copy, restoring a deleted enrollment
   or a superseded GitHub-login-to-local-user binding, and every check passes because

--- a/README.md
+++ b/README.md
@@ -124,11 +124,17 @@ sudo make install
 ```
 
 This installs:
-- `oauth2_pam.so` into this distribution's PAM module directory — asked for with
-  `scripts/pam-module-dir.sh`, not assumed. It is `/lib64/security` on RHEL and
+- `oauth2_pam.so` into this distribution's PAM module directory, worked out by
+  `scripts/pam-module-dir.sh`. It is `/lib64/security` on RHEL and
   `/usr/lib/<triplet>/security` on Debian/Ubuntu multiarch, and a module in the
-  wrong one is a module PAM silently never loads. Override with
-  `PAMDIR=/path make install`.
+  wrong one is a module PAM silently never loads. Where `dpkg` exists the script
+  asks it (`dpkg -L libpam-modules`, and wherever that says `pam_permit.so` lives
+  is where a module goes), which covers the multiarch case that cannot be guessed.
+  Everywhere else it falls back to the first of `/lib64/security`,
+  `/lib/security`, `/usr/lib64/security`, `/usr/lib/security` that exists — a
+  guess, and the right one on the RPM distributions, but a guess. If your host
+  keeps them somewhere else, say so: `PAMDIR=/path make install`, which the script
+  takes as given and does not second-guess.
 - `/usr/local/bin/oauth2-pam-broker`
 - `/usr/local/bin/oauth2-pam-admin`
 - `/usr/local/bin/oauth2-pam-enroll`
@@ -147,10 +153,15 @@ sudo install -m 0600 -o root -g root configs/example.yaml /etc/oauth2-pam/broker
 sudo $EDITOR /etc/oauth2-pam/broker.yaml
 ```
 
-The directory is created explicitly, and `0750`. The broker checks the mode and
-owner of the file that holds the secret; nothing checks the directory around it,
-and a directory another user can write is a config file that user can *replace* —
-which would let them choose the OAuth app this host authenticates against.
+The directory is created explicitly, and `0750`. The broker checks the mode and owner
+of the file that holds the secret **and of the directory around it**, because a
+directory another user can write is a config file that user can *replace* — which
+would let them choose the OAuth app this host authenticates against. A directory that
+is writable by group or other (without the sticky bit) or owned by neither root nor
+the broker is a startup error, not a warning. This paragraph said nothing checked the
+directory until [#109](https://github.com/scttfrdmn/oauth2-pam/issues/109); the check
+has been there since #96, so an operator following the old text got a broker that
+refused to start for a reason they had been told was not checked.
 
 Minimal config:
 
@@ -335,10 +346,32 @@ The mapper resolves a GitHub identity to a local Unix user via a four-tier chain
 
 | Tier | Config key | Description |
 |------|-----------|-------------|
-| 0 | `mapper.enrollment_file` | Self-enrolled users (`oauth2-pam-enroll`) |
+| 0 | `mapper.enrollment_enabled` (plus `mapper.enrollment_file`) | Self-enrolled users (`oauth2-pam-enroll`) |
 | 1 | `mapper.rules` | Built-in YAML rules, zero deps |
 | 2 | `mapper.external_script` | External binary (JSON stdin/stdout) |
 | 3 | `mapper.http_endpoint` | HTTPS service (LDAP gateway, etc.) |
+
+Tier 0 needs both keys, and `mapper.enrollment_enabled: true` is the one that
+switches it on — a path alone does nothing. This table named only the path until
+[#107](https://github.com/scttfrdmn/oauth2-pam/issues/107), which was wrong twice
+over: a config with just `mapper.enrollment_file` does not satisfy "at least one
+tier", so the broker refuses to start, and adding a rule to get past that leaves
+tier 0 never consulted — so every enrolled user is silently ignored while
+`oauth2-pam-enroll` appears to work.
+
+```yaml
+mapper:
+  enrollment_enabled: true
+  enrollment_file: /etc/oauth2-pam/enrolled-users.yaml   # this is the default
+```
+
+The file is read fresh on every login, so enrolling somebody takes effect without a
+restart. It must be a regular file, not a symlink, owned by root, and neither it nor
+its directory may be writable by group or other — tier 0 decides which provider
+identity owns which local account, so whoever can write it chooses who logs in as
+whom. `oauth2-pam-enroll` writes it 0600. A file that fails those checks yields no
+tier-0 answer at all: the login falls through to the later tiers with a warning in
+the broker's log, rather than an untrusted file being honoured.
 
 ### Which local accounts can be mapped to
 
@@ -375,7 +408,7 @@ mapper:
       local_user: octocat
 ```
 
-All `match` fields within a rule are ANDed, and matching is case-insensitive. `local_user` supports `{{ .Login }}` (the provider username), `{{ .Email }}`, and `{{ .Name }}`; nothing else — an unknown field or a pipeline is rejected rather than expanded. The result must be a valid POSIX username or the mapping is refused. A provider whose logins are email addresses therefore cannot use `{{ .Login }}`; give those rules an explicit `local_user`, or map in Tier 2/3.
+All `match` fields within a rule are ANDed, and matching is case-insensitive. `local_user` substitutes three values, each in three spellings: `{{ .Login }}`, `{{.Login}}` or `{login}` (the provider username), and the same forms for `.Email` and `.Name`. Nothing else is substituted. A leftover `{{` after substitution is rejected outright, which is what stops a provider-controlled field turning into a template; a leftover single-brace form like `{bogus}` is left as literal text and then fails the POSIX-username check, so it is refused too, one step later. The result must be a valid POSIX username or the mapping is refused. A provider whose logins are email addresses therefore cannot use `{{ .Login }}`; give those rules an explicit `local_user`, or map in Tier 2/3.
 
 `github_org` and `github_team` are the GitHub spelling of provider-neutral **claims**, and a rule can name claims directly instead:
 
@@ -482,9 +515,14 @@ make test-cbridge-mutations      # put each fixed bridge defect back; the C test
 make test-integration-mutations  # put the v0.1.x bypass back; the harness must refuse the login
 ```
 
-Those two are the check on the checks, and CI runs both on every push and pull
-request — the harness mutation check as its own job, the C bridge one as a step in
-the Linux job, next to the suite it mutates. A green suite proves the code does what the tests say; it does not prove the tests would notice if it stopped — so each of the six C bridge defects fixed in v0.2.0, and the v0.1.x authentication bypass itself, is reintroduced in a copy of the tree and the suite is required to fail. A mutation that survives means that regression test is decoration.
+Those two are the check on the checks, and CI runs both on every push to `main` and
+every pull request — the harness mutation check as its own job, the C bridge one as a
+step in the Linux job, next to the suite it mutates. A green suite proves the code
+does what the tests say; it does not prove the tests would notice if it stopped — so
+each of 25 C bridge defects is reintroduced in turn in a copy of the tree, along with
+the v0.1.x authentication bypass and an account stage that fails open, and the suite
+is required to fail each time. A mutation that survives means that regression test is
+decoration.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for how work is tracked (labels, milestones, the roadmap board), what to run before pushing, and the two invariants that are easy to break.
 
@@ -521,7 +559,7 @@ oauth2-pam/
 ## Security notes
 
 - The documented PAM stack makes this module a **second factor** (`auth required`, after the distribution's own auth stack), not the whole authentication decision. `auth sufficient` hands the decision to one module; v0.1.x is what that costs when the module is wrong. [Configure PAM (SSH)](#6-configure-pam-ssh) has both arrangements and the break-glass checklist.
-- Tokens are held encrypted in memory (AES-256-GCM) and never written to disk. Set `token_encryption_key` with `oauth2-pam-admin gen-key` rather than typing one: 32 typeable characters cannot carry 256 bits. With no key configured the broker generates one for the process instead of storing tokens in the clear — an unrecoverable key is no loss for data that never outlives the process, and it means the default is not plaintext. `secure_token_storage: false` opts out.
+- Tokens are held encrypted in memory (AES-GCM) and never written to disk. Set `token_encryption_key` with `oauth2-pam-admin gen-key` rather than typing one: 32 typeable characters cannot carry 256 bits. A generated (base64, 32-byte) key gives AES-256; a raw 16- or 24-byte key, still accepted for 0.1.x configs, gives AES-128 or AES-192. With no key configured the broker generates one for the process instead of storing tokens in the clear — an unrecoverable key is no loss for data that never outlives the process, and it means the default is not plaintext. `secure_token_storage: false` opts out.
 - Audit records go to `file`, `stdout`, or `syslog`; anything else is a startup error. An unrecognised type used to become `stdout`, so a typo moved the whole trail somewhere nobody was watching.
 - The broker socket is `0660` in a `0750` directory. The PAM module runs as root and so can reach it; other local users cannot, which matters because anything that can talk to the socket can start device flows.
 - The broker rate-limits per calling UID and caps request bodies at 64 KB. The UID comes from the socket's peer credentials (`SO_PEERCRED` on Linux, `LOCAL_PEERCRED` on macOS/FreeBSD); if a platform cannot supply them the broker logs `peer_credentials=false` at startup and every caller shares one window, rather than all being recorded as root.
@@ -529,8 +567,8 @@ oauth2-pam/
 - Session IDs are generated by the broker with `crypto/rand`; a client-supplied `session_id` on an `authenticate` request is ignored.
 - Org and team membership is checked server-side in the broker, before mapping.
 - Enrollment records name the provider they were created against, so on a host with two providers an account with the same login at the other one cannot claim an enrollment. Records written before v0.3.0 name no provider and match any; re-enroll to scope them.
-- The enrollment file is the most authoritative mapping tier, so it is read under the same rules as the client secret: 0600 or tighter, owned by root or the broker's uid, not a symlink, and in a directory no other local user can write. The directory matters because the file's own mode cannot be forged but its *name* can be reused — with write access to `/etc/oauth2-pam` an attacker cannot alter the file, but they can rename it away and put an earlier root-owned copy back, reinstating an enrollment that was deliberately removed. `oauth2-pam-enroll` applies the directory rule when it writes, so the operator hears about it then rather than the enrolled user hearing about it at the login that fails.
-- Authentication events go to the audit log; `audit.events` filters which types are recorded, and an unknown type in that list is a config error rather than a silently ignored one. Events that record an access decision (`authentication_success`, `authentication_failed`, `authentication_denied`, `session_revoked`) are written synchronously, so they survive a crash and cannot be dropped by a full queue; the high-volume `authentication_attempt` is buffered and may be.
+- The enrollment file is the most authoritative mapping tier, so it is read under nearly the same rules as the client secret: not writable by group or other, owned by root or the broker's uid, not a symlink, and in a directory no other local user can write. The one difference is read access, and it is deliberate — a secret must be 0600 or tighter, while a 0640 enrollment file loads. It is still a disclosure, since it says which local account belongs to which provider identity, which is what aiming a device-flow phish at the right person needs; refusing it would lock every enrolled user out of a host whose operator had chmodded it 0640, and that outage is the worse answer. Write is the one that is refused, because write is the whole of tier 0's authority. The directory matters because the file's own mode cannot be forged but its *name* can be reused — with write access to `/etc/oauth2-pam` an attacker cannot alter the file, but they can rename it away and put an earlier root-owned copy back, reinstating an enrollment that was deliberately removed. `oauth2-pam-enroll` applies the directory rule when it writes, so the operator hears about it then rather than the enrolled user hearing about it at the login that fails.
+- Authentication events go to the audit log; `audit.events` filters which types are recorded, and an unknown type in that list is a config error rather than a silently ignored one. The four events that record an access decision (`authentication_success`, `authentication_failed`, `authentication_denied`, `session_revoked`) are exempt from that filter and are written synchronously, so they survive a crash, cannot be dropped by a full queue, and cannot be configured away. That leaves `authentication_attempt` — the high-volume one the buffer exists for — and `device_flow_failed` as the two types `audit.events` can actually drop. A dropped event is counted, not silent.
 - A login whose `authentication_success` record cannot be written is refused rather than granted unrecorded, and that promise is bounded by a five-second deadline on the audit write: a sink that stalls — an `fsync` on an unreachable hard NFS mount, a `/dev/log` whose peer has stopped reading — is treated by the broker as a sink that refused, since a broker waiting forever for an answer never acts on it. The record is written before the session is activated, so no login exists that the trail does not already name. The converse needs saying too, because it is where that fail-closed answer costs something: a write that failed can still have left the record at a sink — every sink is attempted whatever the earlier ones did, a write that overran its deadline is still running with the bytes already in the file, and the file sink itself writes before it `fsync`s, so a full or failing disk reports the failure with the whole record already in the file and readable by anything tailing it — so the trail can name a login that did not happen. Where that is possible the broker follows the success with a `session_revoked` recording that the authentication did not take effect, which is the same correction a grant withdrawn between the record and the activation gets. That correction is best effort by nature: if the sinks have stopped draining it is refused for the same reason the record was, and the broker says so at `error` rather than leaving the impression it succeeded. The practical consequence for an operator is that an audit sink which stops draining stops logins on that host; the alternative is a host that keeps letting people in and recording none of it.
 
 ## Limitations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -83,16 +83,22 @@ This is pre-1.0 software with no third-party audit. Concretely, as of v0.3.0:
   `sshd` over a real ssh connection — is covered by the container harness in
   `test/integration/`.
 - **Both suites are mutation-checked in CI, by scripts you can run yourself.**
-  `test/integration/mutations.sh` rebuilds the module with the v0.1.x bypass
-  reintroduced and requires the harness to refuse the login; `test/cbridge/mutations.sh`
-  reintroduces each of the six C bridge defects fixed in v0.2.0 and requires the
-  C unit tests to fail. Both run in CI on every push and pull request — the
+  `test/integration/mutations.sh` rebuilds the module twice — once with the v0.1.x
+  bypass reintroduced, once with the account stage failing open — and requires the
+  harness to refuse the login both times; `test/cbridge/mutations.sh` reintroduces
+  each of 25 C bridge defects in turn, one per run, and requires the C unit tests
+  to fail. Both run in CI on every push to `main` and every pull request — the
   harness one as its own job (`integration-mutations`), the C bridge one as a step
   in the `linux` job, alongside the suite it mutates — so "these tests would catch
   it" is a check rather than a claim.
 - **A login against real github.com has never been verified by the test suite.**
   Everything above fakes the provider.
-- Tokens are held encrypted in memory (AES-256-GCM) and never written to disk.
+- Tokens are held encrypted in memory (AES-GCM) and never written to disk. The
+  cipher is AES-256 for a generated key or a base64 32-byte one, and AES-128 or
+  AES-192 if a raw 16- or 24-byte `token_encryption_key` is configured — those
+  lengths are accepted for compatibility with 0.1.x configs, and this document said
+  256 unconditionally until
+  [#109](https://github.com/scttfrdmn/oauth2-pam/issues/109).
   With no `token_encryption_key` configured the broker generates one for the
   process, so the shipped default is encryption rather than plaintext; that key
   lives in the same heap as the ciphertext, so it defends against a core dump or
@@ -108,18 +114,31 @@ differences matter if you are relying on one of them:
 
 | Tool | When | A finding fails the run? |
 |---|---|---|
-| CodeQL (`security-extended`) | pushes to `main`, every PR, weekly | yes |
+| CodeQL (`security-extended,security-and-quality`, Go **and** C) | pushes to `main`, every PR, weekly | **no** — alerts go to the Security tab; the job passes |
 | govulncheck | pushes to `main`, every PR, weekly | yes |
 | gosec | pushes to `main`, every PR, weekly | **no** — `continue-on-error`; findings go to the Security tab for triage |
 | Dependency review | pull requests only | yes, at `moderate` |
 | OpenSSF Scorecard | pushes to `main`, weekly — not on PRs | no, it is a posture report |
 
+CodeQL analyzes the C as well as the Go: the job is a `go` + `c-cpp` matrix, and
+because a C database needs a real compile, the `c-cpp` leg installs the PAM and
+json-c headers and runs `make build-pam` under the extractor — the same command CI
+and `release.yml` use, so what is analyzed is what ships. On top of that,
+`cmd/pam-module/cgo_bridge_linux.c` is covered by `test/cbridge`, compiled
+`-Werror -Wall -Wextra -Wconversion` and mutation-checked as described above. This
+document said no scanner analyzed the C at all until
+[#109](https://github.com/scttfrdmn/oauth2-pam/issues/109).
+
 Three gaps worth stating plainly rather than leaving to be inferred:
 
-- **No scanner analyzes the C.** CodeQL runs with `languages: go`, so
-  `cmd/pam-module/cgo_bridge_linux.c` is in no database. What covers it is
-  `test/cbridge` — compiled `-Werror -Wall -Wextra -Wconversion`, and
-  mutation-checked as described above.
+- **Only two of those tools can fail a run, and CodeQL is not one of them.** The
+  `analyze` step has no `fail-on` and there is no CodeQL config setting a threshold,
+  so a new alert appears in the Security tab and the job is green. `govulncheck`
+  exits non-zero and `dependency-review` is set to `fail-on-severity: moderate`;
+  those two are the ones where "fails the run" is backed by something in the file.
+  This table claimed CodeQL failed the run until
+  [#109](https://github.com/scttfrdmn/oauth2-pam/issues/109), which is the wrong
+  direction for a document whose purpose is saying what is actually checked.
 - **A push to a topic branch runs nothing.** Both workflows are `push` on `main`
   plus `pull_request`; the scans reach a branch when it opens a pull request, not
   while it is being pushed to.

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -61,8 +61,14 @@ providers:
     #      and refuses to start otherwise. A secret in a world-readable config
     #      is a secret every local user on the host already has.
     #
-    # Whichever file holds the secret, the same rule applies to it: mode 0600,
-    # owned by root. Set exactly one of client_secret and client_secret_file.
+    # Whichever file holds the secret, the same rule applies to it: mode 0600 or
+    # tighter, and owned by root or by the uid the broker runs as — the broker
+    # accepts either, and this comment said root alone until #109. The directory
+    # holding it is checked too: group- or other-writable (without the sticky bit),
+    # or owned by anyone else, and the broker refuses to start, because a directory
+    # somebody else can write is a file they can replace.
+    #
+    # Set exactly one of client_secret and client_secret_file.
     client_secret: "your-client-secret"     # GitHub OAuth App client secret
     # client_secret_file: github-client-secret
 
@@ -263,9 +269,17 @@ security:
   #   oauth2-pam-admin gen-key
   #
   # That prints a base64-encoded 32 bytes (44 characters), which is the preferred
-  # form. 16, 24, or 32 raw characters are still accepted for compatibility.
-  # Rotating the key invalidates the tokens held in the broker's memory, so the
-  # users holding them must authenticate again; nothing on disk is affected.
+  # form. 16, 24, or 32 raw characters are still accepted for compatibility, and
+  # give AES-128 or AES-192 rather than AES-256.
+  #
+  # Left unset the broker generates a key for the process and still encrypts —
+  # plaintext takes secure_token_storage: false and nothing else. Rotating the key
+  # invalidates the tokens held in the broker's memory, so the users holding them
+  # must authenticate again; nothing on disk is affected.
+  #
+  # A key set here is checked at startup whether or not it will be read, so a
+  # malformed one is a startup error even with secure_token_storage: false — it used
+  # to be exempt, and then failed the day storage was turned back on.
   # token_encryption_key: "paste the output of gen-key here"
 
   # Upper bound on how long a stored token may live. Must be >= token_lifetime
@@ -292,9 +306,16 @@ security:
     max_requests_per_minute: 300
     # Ceiling on device flows awaiting approval broker-wide; each one holds a
     # goroutine polling the provider. Further authenticate requests are refused
-    # with RATE_LIMITED until one finishes or hits device_flow_timeout. Size it
-    # for peak concurrent logins: a refusal is a failed login, and one abandoned
-    # flow holds a slot for device_flow_timeout.
+    # with AUTH_LIMIT_REACHED until one finishes or hits device_flow_timeout.
+    # Size it for peak concurrent logins: a refusal is a failed login, and one
+    # abandoned flow holds a slot for device_flow_timeout.
+    #
+    # AUTH_LIMIT_REACHED, not RATE_LIMITED — this comment said the latter until
+    # #108, and the two are deliberately different answers. RATE_LIMITED comes
+    # from max_requests_per_minute above and means "slow down": the client may
+    # retry. AUTH_LIMIT_REACHED means the capacity is held by other logins, is
+    # terminal for the attempt, and maps to a different PAM result. A client
+    # keying on the wrong one retries a refusal that will not clear.
     max_concurrent_auths: 50
 
 # ---------------------------------------------------------------------------
@@ -313,6 +334,25 @@ audit:
   # started cleanly and wrote its audit trail somewhere nobody was watching.
   # There is no webhook sink — url and headers were parsed and ignored, and are
   # now rejected.
+  #
+  # path must be absolute, and the file and the directory holding it are checked
+  # the way the client secret and the enrollment file are: the open refuses a
+  # symlink (O_NOFOLLOW), the target must be a regular file, and neither it nor
+  # its directory may be writable by group or other. A failure is a startup
+  # error.
+  #
+  # The check that matters most is the symlink one. A link pointing at /dev/null
+  # makes every write succeed, so the broker's fail-closed rule — a login whose
+  # record cannot be written is refused — is satisfied by a sink that keeps
+  # nothing, and every login is granted with no trail behind it. That is the one
+  # audit failure nothing downstream can detect. Group or other write is the
+  # authority to forge or erase the record of an access decision.
+  #
+  # Group *read* is deliberately allowed, so 0640 with an operators group works.
+  # Refusing it would refuse every login on the host, and an outage is a worse
+  # answer to a disclosure than the disclosure — but the trail does name local
+  # accounts, provider logins and email addresses, so 0600 is the default for a
+  # reason.
   outputs:
     - type: file
       path: /var/log/oauth2-pam/audit.log
@@ -332,18 +372,33 @@ audit:
     #   facility: auth
     #   severity: info
 
-  # Only these event types are written; everything else is dropped and counted.
-  # Omit the list entirely to record every event. An unrecognised name here is
-  # a startup error rather than a silent hole in the audit trail, so this list
-  # must be a subset of:
+  # Which event types are written. Omit the list entirely to record every event.
+  # An unrecognised name here is a startup error rather than a silent hole in the
+  # audit trail, so this list must be a subset of the six below.
+  #
+  # The list does not apply to the four events that record an access decision —
+  # authentication_success, authentication_failed, authentication_denied and
+  # session_revoked. Those are written whatever this says, because they are what
+  # an incident is reconstructed from and a volume control is not the place to
+  # decide they are not worth keeping. Leaving one out of this list has no
+  # effect. This comment said "only these event types are written" until #109,
+  # which is safer than documented but the opposite of what an operator editing
+  # it expects.
+  #
+  # So the two types this list can actually drop are authentication_attempt and
+  # device_flow_failed, marked below. A dropped event is counted, not silent.
   #
   #   authentication_attempt   a login attempt began (a device flow started)
-  #   authentication_success   a login was authorized
-  #   authentication_failed    the attempt failed (provider or broker error)
-  #   authentication_denied    the attempt was refused (denial, org/team, or
-  #                            a mapped user that is not the login name)
+  #                            — filterable, and the high-volume one
+  #   authentication_success   a login was authorized (always written)
+  #   authentication_failed    the attempt failed, provider or broker error
+  #                            (always written)
+  #   authentication_denied    the attempt was refused — denial, org/team, or
+  #                            a mapped user that is not the login name
+  #                            (always written)
   #   device_flow_failed       the device flow itself could not be started
-  #   session_revoked          a session was revoked
+  #                            — filterable
+  #   session_revoked          a session was revoked (always written)
   #
   events:
     - authentication_attempt

--- a/docs/wire-protocol.md
+++ b/docs/wire-protocol.md
@@ -166,8 +166,15 @@ should know about:
   ampersands measured 3072 bytes against the budget and serialized to 18432, past
   the whole reply cap on its own, which put #88's lockout straight back. Counted
   after escaping, a maximal reply measures the same ~4 KB whatever its characters
-  are. Control characters are still stripped rather than escaped, so a client will
-  not see them at all.
+  are. Control characters are stripped rather than escaped, so a client will not see
+  them at all — and "control character" here means the same set the broker's prompt
+  sanitizer uses: C0, DEL, **C1 (U+0080–U+009F)**, U+2028 and U+2029. Including C1
+  was [#105](https://github.com/scttfrdmn/oauth2-pam/issues/105): the reply filter
+  had its own narrower rule that stopped at C0 and DEL, so U+009B — which *is* CSI
+  to a terminal decoding UTF-8, and which `encoding/json` does not escape — was
+  forwarded intact to whatever displayed the field. A client can rely on these
+  fields being safe to print, and on there being one policy rather than one per
+  code path.
 - An over-budget `groups` is omitted entirely and `metadata.groups_omitted` is set
   to `"true"`. A truncated list is indistinguishable from a complete one, and a
   client acting on membership would act on a list missing whichever entries sorted

--- a/pkg/auth/broker.go
+++ b/pkg/auth/broker.go
@@ -1779,7 +1779,20 @@ func boundedReplyField(s string, max int) string {
 	var out strings.Builder
 	width := 0
 	for _, r := range s {
-		if r < 0x20 || r == 0x7f {
+		// isDisallowedInPrompt, not a predicate of this function's own — #105. This
+		// used to be `r < 0x20 || r == 0x7f`, which is C0 and DEL and stops there. The
+		// sanitizer three files over rejects C1 as well (U+009B is CSI, and encoding/json
+		// does not escape it, so it reached the audit file, journald and
+		// oauth2-pam-admin's console output as a live escape) plus U+2028 and U+2029.
+		//
+		// Two filters for one class of value, and the weaker one governed the wire. The
+		// value being filtered is the same in both cases — a string the provider or the
+		// mapper chose — so there is one policy, in one place, and both callers ask it.
+		// Newline needs no separate case: isDisallowedInPrompt covers all of C0. Its
+		// comment says newline is "handled by the caller", meaning the caller that has
+		// structural newlines to keep — SanitizePromptBlock and the QR art. A reply
+		// field is single-line, so the answer here is the plain one.
+		if isDisallowedInPrompt(r) {
 			continue
 		}
 		w := escapedRuneWidth(r)
@@ -1796,13 +1809,17 @@ func boundedReplyField(s string, max int) string {
 // inside a JSON string.
 //
 // It follows encoding/json's own encoder with HTML escaping on, which is the
-// default and what internal/ipc's bare json.Marshal uses. Control characters are
-// absent by the time this is reached — boundedReplyField strips them — so the
-// six-byte escape they would take does not appear here; if that stripping is ever
-// removed this function has to grow the case back.
+// default and what internal/ipc's bare json.Marshal uses. C0 and DEL are absent by
+// the time this is reached — boundedReplyField strips them — so the six-byte escape
+// they would take does not appear here; if that stripping is ever removed this
+// function has to grow the case back.
 //
-// The expanding characters are spelled as escapes rather than literals on purpose:
-// U+2028 and U+2029 are invisible in an editor and in a diff.
+// The U+2028 and U+2029 arms are now unreachable through boundedReplyField too,
+// which strips them along with C1 since #105. They are kept because this function
+// answers "how wide is this rune in JSON" for whatever is handed to it, and an
+// answer that is right only for the current caller's filter is a trap for the next
+// caller. The expanding characters are spelled as escapes rather than literals on
+// purpose: U+2028 and U+2029 are invisible in an editor and in a diff.
 func escapedRuneWidth(r rune) int {
 	switch r {
 	case '"', '\\':

--- a/pkg/auth/reply_bounds_test.go
+++ b/pkg/auth/reply_bounds_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -23,26 +24,114 @@ import (
 // These are the field-level bounds. internal/ipc's authorized-reply test measures
 // the result against the cap itself.
 
+// TestBoundedReplyFieldStripsControlCharacters.
+//
+// The assertion is assertNoDisallowedRunes — sanitize_test.go's helper, the strong
+// one — rather than a predicate written here. #105: this test used to assert
+// `r < 0x20 || r == 0x7f`, which was boundedReplyField's own condition restated, and
+// a test that restates the implementation cannot fail for anything the
+// implementation considers printable. It fed no C1, so it did not notice that C1 was
+// exactly what boundedReplyField let past: encoding/json does not escape U+009B, so
+// a raw CSI reached the audit file, journald and oauth2-pam-admin's console output.
+//
+// The helper lives in this package and was already pointed at device_url, user_code
+// and the QR art. Pointing it at the values on the authorized reply is the whole of
+// the fix's test side.
 func TestBoundedReplyFieldStripsControlCharacters(t *testing.T) {
-	// A NUL, a newline, an ESC introducing a terminal sequence, and a DEL.
-	got := boundedReplyField("al\x00ice\n\x1b[2Jbob\x7f", maxReplyEmailBytes)
+	got := boundedReplyField("al"+hostileReplyValue+"ice", maxReplyEmailBytes)
 
-	for i, r := range got {
-		if r < 0x20 || r == 0x7f {
-			t.Errorf("byte %d of %q is control character %#x", i, got, r)
-		}
-	}
-	if !utf8.ValidString(got) {
-		t.Errorf("%q is not valid UTF-8", got)
-	}
-	if strings.ContainsAny(got, "\x00\n\x1b\x7f") {
-		t.Errorf("%q still carries a control character", got)
-	}
+	// allowNewline is false: a reply field is single-line. The callers that pass true
+	// are the ones with structural newlines to keep, the prompt block and the QR art.
+	assertNoDisallowedRunes(t, false, got)
+
 	// The printable remainder survives: stripping is not sanitizing away the value.
-	if !strings.Contains(got, "alice") || !strings.Contains(got, "bob") {
+	if !strings.Contains(got, "al") || !strings.Contains(got, "ice") {
 		t.Errorf("%q dropped printable content", got)
 	}
 }
+
+// TestEveryFieldOnAnAuthorizedReplyIsFiltered is the call-site half, and the half
+// #105 was actually about. boundedReplyField being correct says nothing about
+// whether the values on the reply that somebody else chose go through it.
+//
+// Reflective over the whole reply rather than field by field, for the reason
+// internal/ipc's request test is reflective: a field added later is covered without
+// anybody remembering to come back here.
+func TestEveryFieldOnAnAuthorizedReplyIsFiltered(t *testing.T) {
+	b := &Broker{}
+	resp := b.successResponse(&Session{
+		ID:            strings.Repeat("ab", 16),
+		LocalUser:     "alice", // already through unixUsernameRe by this point
+		Email:         "alice" + hostileReplyValue + "@example.com",
+		ProviderLogin: "alice" + hostileReplyValue,
+		Groups:        []string{"wheel" + hostileReplyValue, "docker" + hostileReplyValue},
+		Provider:      "acme",
+		ExpiresAt:     time.Now().Add(8 * time.Hour),
+		LastAccessed:  time.Now(),
+	})
+
+	// The group list has to be small enough to be carried, so that a group name is a
+	// filtered value on the wire and not an omitted one. If that stopped being true
+	// this test would pass by having nothing left to check.
+	if resp.Metadata["groups_omitted"] == "true" || len(resp.Groups) != 2 {
+		t.Fatalf("the two-group list was not carried (groups=%v omitted=%q); this no longer "+
+			"checks a group name on the wire", resp.Groups, resp.Metadata["groups_omitted"])
+	}
+
+	for _, s := range replyStrings(t, resp) {
+		assertNoDisallowedRunes(t, false, s)
+	}
+}
+
+// replyStrings returns every string anywhere in resp, walking it by reflection so
+// that a field or a metadata key added later is included without an edit here.
+func replyStrings(t *testing.T, resp *AuthResponse) []string {
+	t.Helper()
+	var out []string
+	var walk func(v reflect.Value)
+	walk = func(v reflect.Value) {
+		switch v.Kind() {
+		case reflect.String:
+			out = append(out, v.String())
+		case reflect.Pointer, reflect.Interface:
+			if !v.IsNil() {
+				walk(v.Elem())
+			}
+		case reflect.Slice, reflect.Array:
+			for i := 0; i < v.Len(); i++ {
+				walk(v.Index(i))
+			}
+		case reflect.Map:
+			for _, k := range v.MapKeys() {
+				walk(k)
+				walk(v.MapIndex(k))
+			}
+		case reflect.Struct:
+			for i := 0; i < v.NumField(); i++ {
+				if v.Type().Field(i).IsExported() {
+					walk(v.Field(i))
+				}
+			}
+		}
+	}
+	walk(reflect.ValueOf(resp))
+	if len(out) == 0 {
+		t.Fatal("walked the reply and found no strings; the walk is broken, not the reply")
+	}
+	return out
+}
+
+// hostileReplyValue is what a provider or a mapper tier can put in a value the
+// broker forwards. Every class the prompt sanitizer rejects is present, because #105
+// was the reply filter rejecting a strict subset of them:
+//
+//   - NUL, an ESC introducing a CSI sequence, and DEL — the three the old filter did
+//     catch, kept so that a narrowing of the fix would still fail here;
+//   - U+0085 NEL and U+009B CSI, the C1 controls. U+009B *is* CSI to a terminal
+//     decoding UTF-8, and encoding/json escapes neither, so the old filter forwarded
+//     a live escape to the audit file, journald and oauth2-pam-admin's console;
+//   - U+2028 and U+2029, line breaks to a JavaScript reader of the same JSON.
+const hostileReplyValue = "\x00\x1b[2J\x7f\u0085\u009b2K\u2028\u2029"
 
 func TestBoundedReplyFieldTruncatesOnARuneBoundary(t *testing.T) {
 	// Two-byte runes against an odd budget, so a byte-wise truncation would split

--- a/pkg/auth/token_manager.go
+++ b/pkg/auth/token_manager.go
@@ -60,6 +60,12 @@ func NewTokenManager(cfg *config.Config) (*TokenManager, error) {
 	switch {
 	case !cfg.Security.SecureTokenStorage:
 		log.Warn().Msg("security.secure_token_storage is false; access tokens will be held as plaintext in memory")
+		if cfg.Security.TokenEncryptionKey != "" {
+			// Otherwise the config reads as "tokens are encrypted with this key" and
+			// the warning above reads as being about some other host (#109).
+			log.Warn().Msg("security.token_encryption_key is set but ignored, because " +
+				"security.secure_token_storage is false; remove one of the two")
+		}
 	case cfg.Security.TokenEncryptionKey != "":
 		e, err := security.NewEncryption(cfg.Security.TokenEncryptionKey)
 		if err != nil {
@@ -93,11 +99,26 @@ func (tm *TokenManager) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop shuts down the token manager.
+// Stop shuts down the token manager and drops the cipher.
+//
+// The Destroy call is what makes security.Encryption.Destroy's own documentation
+// ("call it when a key is rotated out or at shutdown") true: it had no non-test
+// caller until #109, so the one shutdown it names never happened. It is ordered
+// after wg.Wait so the cleanup goroutine cannot be mid-Decrypt, and it is safe
+// against a late request either way — Encrypt and Decrypt on a destroyed cipher
+// return an error rather than panicking, and the broker stops the IPC server
+// before it stops this (cmd/broker/main.go), so there should be no late request
+// at all.
+//
+// What it buys is bounded, and encryption.go says so: the round keys are not
+// zeroized, so this makes the cipher unreachable rather than erasing it.
 func (tm *TokenManager) Stop() error {
 	log.Info().Msg("Stopping token manager")
 	close(tm.stopChan)
 	tm.wg.Wait()
+	if tm.encryption != nil {
+		tm.encryption.Destroy()
+	}
 	return nil
 }
 

--- a/pkg/auth/token_manager_test.go
+++ b/pkg/auth/token_manager_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -334,5 +335,55 @@ func TestFingerprintIsStableAndDistinguishing(t *testing.T) {
 	}
 	if len(a) != 32 { // 16 bytes of SHA-256, hex-encoded
 		t.Errorf("fingerprint length = %d, want 32 hex chars", len(a))
+	}
+}
+
+// TestStopDropsTheCipher is #109's other half. security.Encryption.Destroy says to
+// call it "when a key is rotated out or at shutdown", and until this landed it had
+// no caller outside its own test — the shutdown it named did not happen. Asserted
+// through the exported surface: a token that decrypted before Stop must not decrypt
+// after it, and must fail rather than panic.
+func TestStopDropsTheCipher(t *testing.T) {
+	tm, err := NewTokenManager(tokenManagerConfig(encryptionKey))
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	if err := tm.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	id, err := tm.StoreToken("sess-1", "alice", plaintextToken, "", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+	if _, err := tm.GetDecryptedAccessToken(id); err != nil {
+		t.Fatalf("GetDecryptedAccessToken before Stop: %v", err)
+	}
+
+	if err := tm.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	got, err := tm.GetDecryptedAccessToken(id)
+	if err == nil {
+		t.Errorf("GetDecryptedAccessToken returned %q after Stop; the cipher was not destroyed", got)
+	}
+}
+
+// Stop with secure_token_storage off has no cipher to drop, and must not panic on
+// the nil one.
+func TestStopWithoutACipher(t *testing.T) {
+	cfg := tokenManagerConfig("")
+	cfg.Security.SecureTokenStorage = false
+
+	tm, err := NewTokenManager(cfg)
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	if err := tm.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := tm.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -513,6 +513,16 @@ func (c *Config) Validate() error {
 		if o.Type == "file" && o.Path == "" {
 			return fmt.Errorf("audit.outputs[%d].path is required for type \"file\"", i)
 		}
+		// Absolute, like server.socket_path and the mapper script and unlike this
+		// field until #106. Under systemd the working directory is /, so a relative
+		// path put the audit trail at the filesystem root if it landed anywhere at
+		// all — and the permission checks the sink now makes are checks on a
+		// directory nobody named.
+		if o.Type == "file" && o.Path != "" && !filepath.IsAbs(o.Path) {
+			return fmt.Errorf("audit.outputs[%d].path %q must be an absolute path; the broker's "+
+				"working directory under systemd is /, so a relative path does not name the file "+
+				"the operator meant", i, o.Path)
+		}
 		if o.Type != "file" && o.Path != "" {
 			return fmt.Errorf("audit.outputs[%d].path applies only to type \"file\", not %q", i, o.Type)
 		}
@@ -523,7 +533,14 @@ func (c *Config) Validate() error {
 
 	// What counts as a valid key is defined once, in pkg/security/keys, so this
 	// check and the one at cipher construction cannot drift apart.
-	if c.Security.SecureTokenStorage && c.Security.TokenEncryptionKey != "" {
+	//
+	// Checked whenever a key is present, not only when it is about to be used
+	// (#109). A key configured alongside secure_token_storage: false is not read by
+	// anything, so a malformed one used to sit in the file unremarked until the day
+	// storage was turned back on — at which point the broker refuses to start, and
+	// the change being blamed is the one-line one that did not introduce the fault.
+	// A value in this field is either a key or a mistake.
+	if c.Security.TokenEncryptionKey != "" {
 		if err := keys.Validate(c.Security.TokenEncryptionKey); err != nil {
 			return fmt.Errorf("security.token_encryption_key %w", err)
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -154,6 +154,15 @@ func TestValidate(t *testing.T) {
 		{"facility on a file output", func(c *Config) {
 			c.Audit.Outputs = []AuditOutput{{Type: "file", Path: "/tmp/a.log", Facility: "auth"}}
 		}, "apply only to type"},
+		// #106. The broker's working directory under systemd is /, so a relative path
+		// names a file at the filesystem root — and the sink's new permission checks
+		// would then be checking a directory nobody chose.
+		{"relative file output path", func(c *Config) {
+			c.Audit.Outputs = []AuditOutput{{Type: "file", Path: "audit.log"}}
+		}, "must be an absolute path"},
+		{"file output path relative to a directory", func(c *Config) {
+			c.Audit.Outputs = []AuditOutput{{Type: "file", Path: "../../etc/audit.log"}}
+		}, "must be an absolute path"},
 		{"file output with a path", func(c *Config) {
 			c.Audit.Outputs = []AuditOutput{{Type: "file", Path: "/var/log/oauth2-pam/audit.log"}}
 		}, ""},
@@ -169,12 +178,20 @@ func TestValidate(t *testing.T) {
 		// The generated form: base64, 44 characters. Validate must accept what
 		// `oauth2-pam-admin gen-key` prints.
 		{"generated base64 key", func(c *Config) { c.Security.TokenEncryptionKey = generatedKey }, ""},
+		// A key is checked even where nothing will read it (#109). It used to be
+		// exempt when storage was off, so a malformed key waited in the file for
+		// whoever turned storage back on and then blamed that change.
 		{
-			"key length is unchecked when encryption is off",
+			"key length is checked even when encryption is off",
 			func(c *Config) {
 				c.Security.SecureTokenStorage = false
 				c.Security.TokenEncryptionKey = "short"
 			},
+			"token_encryption_key",
+		},
+		{
+			"no key at all is still fine when encryption is off",
+			func(c *Config) { c.Security.SecureTokenStorage = false },
 			"",
 		},
 

--- a/pkg/config/doc_keys_test.go
+++ b/pkg/config/doc_keys_test.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Every config key the documentation names has to exist — #107.
+//
+// README.md gave tier 0's config key as `mapper.enrollment_file`, and the key that
+// switches tier 0 on is `mapper.enrollment_enabled`. Following the README produced a
+// broker that refused to start ("at least one tier must be configured"), and adding
+// a rule to get past that produced one where tier 0 was never consulted, so every
+// enrolled user was silently ignored while oauth2-pam-enroll appeared to work.
+//
+// The structural gap is why it lasted: config_test.go loads and validates the
+// shipped configs/example.yaml, so the example is protected by a test and the prose
+// is not. This closes that by taking the documentation's word for it — every dotted
+// key in backticks under a known top-level section has to resolve to a real
+// mapstructure tag.
+//
+// It does not check that a key means what the prose says it means. Nothing
+// mechanical can. It checks the one thing that keeps being wrong: whether the key is
+// there at all.
+func TestEveryConfigKeyNamedInTheDocsExists(t *testing.T) {
+	valid := configKeys(reflect.TypeOf(Config{}), "")
+	sections := map[string]bool{}
+	for k := range valid {
+		sections[strings.Split(k, ".")[0]] = true
+	}
+
+	for _, file := range docFiles(t) {
+		body, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		for _, key := range dottedKeysIn(string(body), sections) {
+			if _, ok := valid[key]; !ok {
+				t.Errorf("%s names config key %q, which does not exist. Candidates: %s",
+					filepath.Base(file), key, strings.Join(nearestKeys(key, valid), ", "))
+			}
+		}
+	}
+}
+
+// docFiles is every prose file an operator is expected to configure from. Named
+// explicitly rather than globbed from the repository root, so that a new document
+// is added here deliberately and a stray file elsewhere does not fail the suite.
+func docFiles(t *testing.T) []string {
+	t.Helper()
+	// This test runs in pkg/config, so the repository root is two levels up.
+	root := filepath.Join("..", "..")
+	files := []string{
+		filepath.Join(root, "README.md"),
+		filepath.Join(root, "SECURITY.md"),
+	}
+	docs, err := filepath.Glob(filepath.Join(root, "docs", "*.md"))
+	if err != nil {
+		t.Fatalf("glob docs: %v", err)
+	}
+	files = append(files, docs...)
+	for _, f := range files {
+		if _, err := os.Stat(f); err != nil {
+			t.Fatalf("stat %s: %v — this test's file list has gone stale", f, err)
+		}
+	}
+	return files
+}
+
+// docKeyRe matches a dotted lower-case token, with optional [] or [0] index
+// segments: mapper.min_uid, providers[].name, audit.outputs[].path.
+var docKeyRe = regexp.MustCompile(`^[a-z0-9_]+(\[\]|\[[0-9]+\])?(\.[a-z0-9_]+(\[\]|\[[0-9]+\])?)+$`)
+
+// indexRe strips the index segments, since a slice's element fields live under the
+// slice's own key.
+var indexRe = regexp.MustCompile(`\[[0-9]*\]`)
+
+// dottedKeysIn returns the config keys named in backticks in body.
+//
+// Backticks are the filter that makes this safe to run over prose: an unquoted
+// "audit outputs" is not a claim about a key. The section filter is the second — it
+// is what keeps `github.com`, `api.github.com` and every other dotted thing in a
+// document about OAuth2 from being read as configuration.
+func dottedKeysIn(body string, sections map[string]bool) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, span := range strings.Split(body, "`")[1:] {
+		token := strings.TrimSpace(span)
+		if !docKeyRe.MatchString(token) {
+			continue
+		}
+		key := indexRe.ReplaceAllString(token, "")
+		if !sections[strings.Split(key, ".")[0]] || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// configKeys returns every dotted mapstructure path in t.
+//
+// A slice of structs contributes its own key and its element's fields beneath it, so
+// providers[].name and audit.outputs[].path resolve. A map stops the walk: its keys
+// are data, not configuration — mapper.rules[].claims is a set of provider claim
+// names, and no list of them could be checked here.
+func configKeys(t reflect.Type, prefix string) map[string]struct{} {
+	keys := map[string]struct{}{}
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return keys
+	}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		tag := strings.Split(f.Tag.Get("mapstructure"), ",")[0]
+		if tag == "" || tag == "-" {
+			continue
+		}
+		key := tag
+		if prefix != "" {
+			key = prefix + "." + tag
+		}
+		keys[key] = struct{}{}
+
+		ft := f.Type
+		for ft.Kind() == reflect.Pointer || ft.Kind() == reflect.Slice || ft.Kind() == reflect.Array {
+			ft = ft.Elem()
+		}
+		if ft.Kind() == reflect.Struct {
+			for k := range configKeys(ft, key) {
+				keys[k] = struct{}{}
+			}
+		}
+	}
+	return keys
+}
+
+// nearestKeys returns the real keys sharing the bad key's section, so a failure says
+// what the writer probably meant rather than only that they were wrong.
+func nearestKeys(bad string, valid map[string]struct{}) []string {
+	section := strings.Split(bad, ".")[0] + "."
+	var out []string
+	for k := range valid {
+		if strings.HasPrefix(k, section) {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestTheDocKeyScanFindsTheKeysTheDocsActuallyName is the control. The test above
+// passes trivially if the scan finds nothing — a broken regexp, a changed section
+// name, a file list gone stale — and "no keys named in the docs" is exactly what a
+// silently-broken scan looks like.
+func TestTheDocKeyScanFindsTheKeysTheDocsActuallyName(t *testing.T) {
+	valid := configKeys(reflect.TypeOf(Config{}), "")
+	sections := map[string]bool{}
+	for k := range valid {
+		sections[strings.Split(k, ".")[0]] = true
+	}
+
+	found := map[string]bool{}
+	for _, file := range docFiles(t) {
+		body, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		for _, k := range dottedKeysIn(string(body), sections) {
+			found[k] = true
+		}
+	}
+
+	// The tier-0 key #107 was about, plus one from each of the other files that name
+	// any, so a scan that stopped reading one of them fails here.
+	for _, want := range []string{
+		"mapper.enrollment_enabled",
+		"mapper.min_uid",
+		"providers.name",
+		"server.read_timeout",
+	} {
+		if !found[want] {
+			t.Errorf("the scan did not find %q in the documentation, so it is not reading what it "+
+				"is meant to be checking", want)
+		}
+	}
+	if len(found) < 8 {
+		t.Errorf("the scan found only %d config keys across the documentation (%v); it found 13 when "+
+			"it was written, so it has probably stopped matching", len(found), found)
+	}
+}

--- a/pkg/enrollment/store.go
+++ b/pkg/enrollment/store.go
@@ -55,12 +55,18 @@ type Store struct {
 // mapper.Chain.ValidateLocalUser.
 type LocalUserValidator func(localUser string) error
 
-// Unvalidated is what a caller passes to Add when it has no mapper configuration
+// unvalidated is what a caller passes to Add when it has no mapper configuration
 // to validate against, and therefore cannot say whether the name it is recording
 // could ever authenticate. Named rather than a bare nil so that the callers making
 // that choice can be found by grep. Production writers should pass the mapper's
 // gate; a record that fails it is one the mapper will refuse at login.
-var Unvalidated LocalUserValidator
+//
+// Unexported since #109. It was exported so that such callers could be grepped
+// for, and the grep has stayed at zero outside this package's own tests — which is
+// the outcome it was watching for, so an exported sentinel is now only an
+// invitation to a first one. Passing nil to Add is identical and always was; what
+// the name buys is that doing so is legible at the call site.
+var unvalidated LocalUserValidator
 
 // Load reads the enrollment file at path. If the file does not exist, an
 // empty Store is returned without error.
@@ -258,7 +264,7 @@ func (s *Store) FindByLocalUser(localUser string) *Record {
 // store from loading or from being written back: the mapper refuses such a record
 // at login on its own, and making Load fail would turn one unusable enrollment
 // into a broken enrollment file for everybody, including the operator trying to
-// remove it. Pass Unvalidated if there is no configuration to validate against.
+// remove it. Pass nil (see unvalidated) if there is no configuration to validate against.
 func (s *Store) Add(rec Record, validate LocalUserValidator) error {
 	// A record is half of a pair, and a record with no login is half of nothing.
 	// Written out it would be a record Find could only ever match against an

--- a/pkg/enrollment/store_test.go
+++ b/pkg/enrollment/store_test.go
@@ -388,7 +388,7 @@ func TestARecordWithNoLoginIsNotAWildcard(t *testing.T) {
 func TestAddRequiresALogin(t *testing.T) {
 	store := &Store{}
 
-	err := store.Add(Record{LocalUser: "alice"}, Unvalidated)
+	err := store.Add(Record{LocalUser: "alice"}, unvalidated)
 	if err == nil {
 		t.Fatal("Add accepted a record with no provider login; it would match any identity that also has none")
 	}
@@ -420,11 +420,11 @@ func TestFindByLocalUser(t *testing.T) {
 func TestAddRejectsDuplicateLocalUser(t *testing.T) {
 	store := &Store{}
 
-	if err := store.Add(Record{LocalUser: "alice", Login: "alice-gh"}, Unvalidated); err != nil {
+	if err := store.Add(Record{LocalUser: "alice", Login: "alice-gh"}, unvalidated); err != nil {
 		t.Fatalf("first Add: %v", err)
 	}
 
-	err := store.Add(Record{LocalUser: "alice", Login: "mallory-gh"}, Unvalidated)
+	err := store.Add(Record{LocalUser: "alice", Login: "mallory-gh"}, unvalidated)
 	if err == nil {
 		t.Fatal("Add silently re-enrolled an existing local user under a different GitHub account")
 	}
@@ -441,10 +441,10 @@ func TestAddRejectsDuplicateLocalUser(t *testing.T) {
 
 func TestAddDuplicateIsCaseInsensitive(t *testing.T) {
 	store := &Store{}
-	if err := store.Add(Record{LocalUser: "alice", Login: "alice-gh"}, Unvalidated); err != nil {
+	if err := store.Add(Record{LocalUser: "alice", Login: "alice-gh"}, unvalidated); err != nil {
 		t.Fatalf("first Add: %v", err)
 	}
-	if err := store.Add(Record{LocalUser: "ALICE", Login: "mallory-gh"}, Unvalidated); err == nil {
+	if err := store.Add(Record{LocalUser: "ALICE", Login: "mallory-gh"}, unvalidated); err == nil {
 		t.Error("Add accepted a duplicate that differed only in case")
 	}
 }
@@ -481,7 +481,7 @@ func TestRemoveThenAddAllowsReEnrollment(t *testing.T) {
 	if !store.Remove("alice") {
 		t.Fatal("Remove failed")
 	}
-	if err := store.Add(Record{LocalUser: "alice", Login: "alice-new-gh"}, Unvalidated); err != nil {
+	if err := store.Add(Record{LocalUser: "alice", Login: "alice-new-gh"}, unvalidated); err != nil {
 		t.Fatalf("re-enrollment after Remove: %v", err)
 	}
 	if rec := store.FindByLocalUser("alice"); rec == nil || rec.Login != "alice-new-gh" {

--- a/pkg/security/audit.go
+++ b/pkg/security/audit.go
@@ -250,6 +250,13 @@ func (al *AuditLogger) LogAuthEventErr(event AuditEvent) error {
 		event.EventID = fmt.Sprintf("audit_%d", time.Now().UnixNano())
 	}
 
+	// Bounded here rather than in writeEvent, which is the other candidate for "the
+	// one place every record passes through": an oversized event that is only bounded
+	// at write time still sits in eventChan at full size until the dispatcher reaches
+	// it, and the queue is 1000 deep. See audit_bounds.go for what is bounded and
+	// why the bound is here rather than at the call sites that build events.
+	event = boundEvent(event)
+
 	if critical {
 		return al.writeEvent(event)
 	}
@@ -613,10 +620,19 @@ type fileOutput struct {
 	file *os.File
 }
 
+// newFileOutput opens the audit file. The open, and the checks around it, are in
+// audit_perms.go — this was the one file open in the tree without O_NOFOLLOW, a
+// mode check or a directory check (#106).
+//
+// A failure here refuses to start the broker, which is the same answer pkg/config
+// and pkg/enrollment give for their files. It is a stronger statement on this path
+// because it is the one that would otherwise fail silently: a sink that accepts
+// records and keeps none satisfies the fail-closed guarantee vacuously, so every
+// login is granted and the trail is empty.
 func newFileOutput(cfg config.AuditOutput) (*fileOutput, error) {
-	f, err := os.OpenFile(cfg.Path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	f, err := openAuditFile(cfg.Path)
 	if err != nil {
-		return nil, fmt.Errorf("open audit file %s: %w", cfg.Path, err)
+		return nil, err
 	}
 	return &fileOutput{file: f}, nil
 }

--- a/pkg/security/audit_bounds.go
+++ b/pkg/security/audit_bounds.go
@@ -1,0 +1,266 @@
+package security
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// How large an audit record is allowed to be, and why the answer is not "as large
+// as the truth" — #104.
+//
+// An AuditEvent carries strings the broker did not choose: an email and a login
+// from the identity provider, a group list from the mapper, and a claims map that
+// is whatever the provider's user endpoint returned. None of those had a byte
+// bound anywhere. pkg/provider/github's apiGetAll bounds pages (20) and entries
+// (2000) and never the accumulated size; provider.AddClaim bounds nothing.
+//
+// That would be a memory question and not much else if the record were written on
+// a background goroutine. It is not: an event recording an access decision is
+// marshalled and fsynced on the login's own goroutine, and a write that fails
+// refuses the login. So an oversized record is not merely a large log line, it is
+// a slow login, and — once the volume it is written to fills — a host that refuses
+// every login after it. The fail-closed guarantee is what turns a disk-space
+// problem into an outage, which is the reason to bound the input rather than to
+// widen the disk.
+//
+// Measured before this existed: 2000 claim entries of 10 KiB produced a single
+// 20,495,142-byte record, marshalled in 25 ms and written synchronously in 17 ms.
+//
+// The reply path already bounds these same three values — boundedReplyField for
+// the email and the provider login, replyGroups for the groups — and pkg/mapper's
+// comment on accepting a 1 MB answer says the extra "is used for the decision and
+// then left out of the reply". It was not left out of the record. The bound lives
+// here, at the one point every producer of every event passes through, rather than
+// at the call site that happened to be found: #102 and #104 are both a mitigation
+// that was correct and had a caller who did not use it, and a per-call-site fix
+// invites the third one.
+const (
+	// maxAuditStringBytes bounds each single-line string field. Deliberately larger
+	// than any equivalent ceiling on the reply (the widest is the 512-byte error
+	// message), so that nothing a client is told is missing from the trail — a record
+	// less complete than the message it describes would be the worse failure.
+	maxAuditStringBytes = 1024
+
+	// maxAuditGroupBytes and maxAuditGroups bound the mapper's group list: 128
+	// entries of 256 bytes, so 32 KiB in the worst case. A Unix group name cannot
+	// approach 256 bytes and a user cannot be in 128 groups that matter, but both are
+	// well clear of any real answer.
+	maxAuditGroupBytes = 256
+	maxAuditGroups     = 128
+
+	// maxAuditMetadataKeys and maxAuditMetadataValueBytes bound Metadata, which is
+	// map[string]interface{} and therefore the only field whose size no type bounds.
+	// The value budget is measured on the marshalled form, because that is the thing
+	// being written and a nested map's size is not visible any other way.
+	maxAuditMetadataKeys       = 32
+	maxAuditMetadataValueBytes = 4096
+
+	// maxAuditRecordBytes is the backstop, applied to the marshalled record after
+	// every field bound above. It exists because the per-field bounds are a sum, and
+	// a sum is an argument rather than a limit: this is the limit.
+	maxAuditRecordBytes = 64 * 1024
+)
+
+// auditTruncationKey is the metadata key under which a record says what it lost.
+//
+// A truncated record that does not say so is worse than either a complete one or a
+// refused one, because it reads as complete: an investigator counting a user's
+// groups would count the ones that fit. Every path below that drops or shortens
+// anything records it here, and the key is reserved — a producer's own value under
+// this name is replaced rather than merged, so nothing can forge "nothing was
+// truncated".
+const auditTruncationKey = "audit_truncated"
+
+// boundEvent returns event with every field it does not control bounded, and a
+// note under auditTruncationKey saying what that cost.
+//
+// Applied in LogAuthEventErr before the critical/queued split, so an oversized
+// event never reaches the channel either — queueing 20 MB to be dropped later is
+// still 20 MB held.
+func boundEvent(event AuditEvent) AuditEvent {
+	var lost []string
+
+	// The fields that arrive over IPC (user_id, source_ip, target_host, session_id)
+	// are bounded by internal/ipc's requestFields before they get here, and the ones
+	// this package sets (event_type, event_id) are literals. They are bounded anyway:
+	// the point of a chokepoint is not to depend on what reached it.
+	event.EventType = boundAuditString(event.EventType, "event_type", &lost)
+	event.EventID = boundAuditString(event.EventID, "event_id", &lost)
+	event.UserID = boundAuditString(event.UserID, "user_id", &lost)
+	event.Email = boundAuditString(event.Email, "email", &lost)
+	event.SourceIP = boundAuditString(event.SourceIP, "source_ip", &lost)
+	event.TargetHost = boundAuditString(event.TargetHost, "target_host", &lost)
+	event.SessionID = boundAuditString(event.SessionID, "session_id", &lost)
+	event.Provider = boundAuditString(event.Provider, "provider", &lost)
+	event.AuthMethod = boundAuditString(event.AuthMethod, "auth_method", &lost)
+	event.ErrorMessage = boundAuditString(event.ErrorMessage, "error_message", &lost)
+	event.ErrorCode = boundAuditString(event.ErrorCode, "error_code", &lost)
+
+	event.Groups = boundAuditGroups(event.Groups, &lost)
+	event.Metadata = boundAuditMetadata(event.Metadata, &lost)
+
+	if len(lost) == 0 {
+		return event
+	}
+	if event.Metadata == nil {
+		event.Metadata = make(map[string]interface{}, 1)
+	}
+	sort.Strings(lost)
+	event.Metadata[auditTruncationKey] = lost
+
+	// The note itself can push a record that just fitted over the backstop, so the
+	// backstop is checked after it is added, not before.
+	return backstopEvent(event)
+}
+
+// boundAuditString truncates s to maxAuditStringBytes on a rune boundary and
+// appends field to lost if anything went.
+//
+// Truncating rather than dropping, because a shortened email or error message
+// still identifies the login it belongs to, and identifying the login is most of
+// what the field is for.
+func boundAuditString(s, field string, lost *[]string) string {
+	if len(s) <= maxAuditStringBytes {
+		return s
+	}
+	*lost = append(*lost, field)
+	return truncateAtRuneBoundary(s, maxAuditStringBytes)
+}
+
+// truncateAtRuneBoundary cuts s to at most max bytes without splitting a rune. A
+// split rune would make the record invalid UTF-8, which json.Marshal answers by
+// substituting U+FFFD — a silent edit to a field that is being recorded precisely
+// so it can be read back verbatim.
+func truncateAtRuneBoundary(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	end := max
+	for end > 0 && !utf8Start(s[end]) {
+		end--
+	}
+	return s[:end]
+}
+
+// utf8Start reports whether b begins a UTF-8 sequence, i.e. is not a continuation
+// byte (0b10xxxxxx).
+func utf8Start(b byte) bool { return b&0xc0 != 0x80 }
+
+// boundAuditGroups omits the group list entirely when it does not fit, rather than
+// truncating it.
+//
+// This is the reply's rule, for the reply's reason, which docs/wire-protocol.md
+// states as "a truncated list is indistinguishable from a complete one, and a
+// client acting on membership would act on a list missing whichever entries sorted
+// last. Omission is at least honest." An investigator reading the trail is that
+// client. The count is kept, because "this user was in 4000 groups" is the useful
+// half of an answer that does not fit.
+func boundAuditGroups(groups []string, lost *[]string) []string {
+	if len(groups) == 0 {
+		return groups
+	}
+
+	total := 0
+	oversize := false
+	for _, g := range groups {
+		if len(g) > maxAuditGroupBytes {
+			oversize = true
+		}
+		total += len(g)
+	}
+	if len(groups) <= maxAuditGroups && !oversize && total <= maxAuditGroups*maxAuditGroupBytes {
+		return groups
+	}
+
+	*lost = append(*lost, fmt.Sprintf("groups (%d entries omitted)", len(groups)))
+	return nil
+}
+
+// boundAuditMetadata bounds the one field whose type bounds nothing.
+//
+// Each value is measured on its marshalled form, which is the only way to see the
+// size of a nested map — identity.Claims arrives here as map[string]interface{} of
+// unknown depth. A value that does not fit is replaced by a note giving its size
+// rather than dropped, so the trail says a claim set was present and how big it
+// was; a value that will not marshal at all is replaced too, rather than being
+// left to fail the whole record.
+func boundAuditMetadata(md map[string]interface{}, lost *[]string) map[string]interface{} {
+	if len(md) == 0 {
+		return md
+	}
+
+	keys := make([]string, 0, len(md))
+	for k := range md {
+		// Reserved: a producer does not get to write the field that says what was
+		// truncated, or "nothing was" becomes forgeable.
+		if k == auditTruncationKey {
+			*lost = append(*lost, "metadata."+auditTruncationKey+" (reserved key discarded)")
+			continue
+		}
+		keys = append(keys, k)
+	}
+	// Sorted so that which keys survive a key-count overflow is deterministic, and
+	// so two records of the same shape lose the same fields.
+	sort.Strings(keys)
+
+	out := make(map[string]interface{}, len(keys))
+	for i, k := range keys {
+		if i >= maxAuditMetadataKeys {
+			*lost = append(*lost, fmt.Sprintf("metadata (%d of %d keys omitted)",
+				len(keys)-maxAuditMetadataKeys, len(keys)))
+			break
+		}
+		bk := boundAuditString(k, "metadata key "+k, lost)
+		encoded, err := json.Marshal(md[k])
+		switch {
+		case err != nil:
+			// Left exactly as it arrived, which means writeEvent's json.Marshal fails and
+			// LogAuthEventErr returns an error reporting the record as never written.
+			//
+			// Substituting a note here instead would be a kindness with a cost: it would
+			// make an unmarshallable event succeed, and the contract that says so — a
+			// marshal failure is the one failure where no sink can hold the record, so
+			// RecordMayHaveLanded is false and the caller must not write a correction
+			// (#94) — would have no reachable path left to test. This function bounds
+			// size; it does not decide what a broken producer's event means.
+			out[bk] = md[k]
+		case len(encoded) > maxAuditMetadataValueBytes:
+			*lost = append(*lost, fmt.Sprintf("metadata.%s (%d bytes omitted)", k, len(encoded)))
+			out[bk] = fmt.Sprintf("[!] value omitted: %d bytes, over the %d-byte limit",
+				len(encoded), maxAuditMetadataValueBytes)
+		default:
+			out[bk] = md[k]
+		}
+	}
+	return out
+}
+
+// backstopEvent enforces maxAuditRecordBytes on the marshalled record.
+//
+// The per-field bounds above sum to well under the cap for any plausible event, so
+// reaching this is either a field nobody enumerated or a producer with far more
+// metadata keys than expected. Either way the answer is the same: keep the fields
+// that identify the access decision — which is what the record exists for and what
+// a caller refusing a login needs it to contain — and say that the rest went.
+//
+// A marshal failure is left alone. writeEvent marshals next and reports it, and
+// that path is tested; guessing at a repair here would only hide it.
+func backstopEvent(event AuditEvent) AuditEvent {
+	data, err := json.Marshal(event)
+	if err != nil || len(data) <= maxAuditRecordBytes {
+		return event
+	}
+
+	note := fmt.Sprintf("[!] record was %d bytes, over the %d-byte limit; "+
+		"groups and metadata were dropped to fit", len(data), maxAuditRecordBytes)
+	event.Groups = nil
+	event.Metadata = map[string]interface{}{auditTruncationKey: note}
+
+	// Still over, with no groups and no metadata left: the remaining fields are the
+	// bounded scalars, whose sum is under a few KiB, so this cannot happen from the
+	// paths above. Returned as it is rather than mangled further — writeEvent will
+	// write it, and a record slightly over a self-imposed cap is better than one this
+	// function invented.
+	return event
+}

--- a/pkg/security/audit_bounds_test.go
+++ b/pkg/security/audit_bounds_test.go
@@ -1,0 +1,265 @@
+package security
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/scttfrdmn/oauth2-pam/pkg/config"
+)
+
+// How large a record the provider gets to make the broker write — #104.
+//
+// The three values the broker does not choose (the provider's email and login, the
+// mapper's groups, the provider's claims) are bounded on the reply and were not
+// bounded on the record. Since a critical record is marshalled and fsynced on the
+// login's own goroutine, and a failed write refuses the login, an unbounded record
+// is not a large log line but a host that stops granting logins once its log volume
+// fills.
+//
+// These tests measure the record, because a bound stated in constants is a claim
+// about arithmetic and the thing that matters is the bytes.
+
+// recordFor returns the bytes a sink would receive for event.
+func recordFor(t *testing.T, event AuditEvent) []byte {
+	t.Helper()
+	sink := &capturingOutput{}
+	al := loggerWithSinks(t, sink)
+	if err := al.LogAuthEventErr(event); err != nil {
+		t.Fatalf("LogAuthEventErr: %v", err)
+	}
+	if len(sink.records) != 1 {
+		t.Fatalf("the sink saw %d records, want 1", len(sink.records))
+	}
+	return sink.records[0]
+}
+
+type capturingOutput struct {
+	records [][]byte
+}
+
+func (o *capturingOutput) Write(b []byte) error {
+	o.records = append(o.records, append([]byte(nil), b...))
+	return nil
+}
+
+func (o *capturingOutput) Close() error { return nil }
+
+// TestAProviderCannotChooseHowLargeAnAuditRecordIs is the regression test. The
+// numbers are the ones apiGetAll and AddClaim actually permit: 2000 entries is its
+// entry cap, and nothing bounds an entry's length.
+func TestAProviderCannotChooseHowLargeAnAuditRecordIs(t *testing.T) {
+	claims := make(map[string]interface{}, 2000)
+	for i := 0; i < 2000; i++ {
+		claims[fmt.Sprintf("claim_%d", i)] = strings.Repeat("x", 10*1024)
+	}
+	groups := make([]string, 3000)
+	for i := range groups {
+		groups[i] = fmt.Sprintf("group-%d-%s", i, strings.Repeat("y", 200))
+	}
+
+	record := recordFor(t, AuditEvent{
+		EventType: "authentication_success",
+		UserID:    "alice",
+		Email:     strings.Repeat("e", 64*1024) + "@example.com",
+		Groups:    groups,
+		Success:   true,
+		Metadata: map[string]interface{}{
+			"provider_login": strings.Repeat("L", 32*1024),
+			"claims":         claims,
+		},
+	})
+
+	if len(record) > maxAuditRecordBytes {
+		t.Errorf("the record is %d bytes, over the %d-byte cap; this is written and fsynced on the "+
+			"login's goroutine, and once the volume fills every later login on the host is refused",
+			len(record), maxAuditRecordBytes)
+	}
+	if !utf8.Valid(record) {
+		t.Error("the record is not valid UTF-8; a field was cut mid-rune")
+	}
+
+	// The record has to remain the thing it exists for: an identification of the
+	// access decision. A bound that dropped user_id would pass the size assertion
+	// and destroy the trail.
+	var got AuditEvent
+	if err := json.Unmarshal(record, &got); err != nil {
+		t.Fatalf("the bounded record does not parse: %v", err)
+	}
+	if got.UserID != "alice" {
+		t.Errorf("user_id = %q, want alice: the record no longer says whose login it describes", got.UserID)
+	}
+	if got.EventType != "authentication_success" {
+		t.Errorf("event_type = %q, want authentication_success", got.EventType)
+	}
+	if !got.Success {
+		t.Error("success = false on a record built with Success: true")
+	}
+	if got.Metadata[auditTruncationKey] == nil {
+		t.Error("the record lost fields and does not say so; a truncated record that reads as " +
+			"complete is worse than either a complete one or a refused one")
+	}
+}
+
+// TestAnOversizedGroupListIsOmittedRatherThanTruncated: the reply's rule, applied
+// to the record. docs/wire-protocol.md's reason is that a truncated list is
+// indistinguishable from a complete one, and whoever reads the trail to answer
+// "was this user in wheel?" is exactly the client that reason is about.
+func TestAnOversizedGroupListIsOmittedRatherThanTruncated(t *testing.T) {
+	groups := make([]string, maxAuditGroups+1)
+	for i := range groups {
+		groups[i] = fmt.Sprintf("group-%d", i)
+	}
+
+	record := recordFor(t, AuditEvent{
+		EventType: "authentication_success",
+		UserID:    "alice",
+		Groups:    groups,
+	})
+
+	var got AuditEvent
+	if err := json.Unmarshal(record, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Groups) != 0 {
+		t.Errorf("groups has %d of %d entries; a partial membership list reads as a complete one",
+			len(got.Groups), len(groups))
+	}
+	note, _ := json.Marshal(got.Metadata[auditTruncationKey])
+	if !strings.Contains(string(note), fmt.Sprintf("%d entries", len(groups))) {
+		t.Errorf("the record does not say how many groups it dropped; note = %s", note)
+	}
+}
+
+// TestAnOrdinaryEventIsRecordedByteForByte is the control, and the one that would
+// catch a bound set too tight. Every field of a real authentication_success from
+// broker.go has to survive verbatim — a fix that truncated ordinary emails or
+// dropped ordinary group lists would destroy the trail far more thoroughly than the
+// defect it was fixing.
+func TestAnOrdinaryEventIsRecordedByteForByte(t *testing.T) {
+	event := AuditEvent{
+		EventType:  "authentication_success",
+		UserID:     "alice",
+		Email:      "alice@example.com",
+		Groups:     []string{"wheel", "docker", "users"},
+		SessionID:  "0123456789abcdef0123456789abcdef",
+		Provider:   "github",
+		AuthMethod: "github_device_flow",
+		SourceIP:   "2001:db8::1",
+		TargetHost: "login.example.edu",
+		Success:    true,
+		Metadata: map[string]interface{}{
+			"provider_login":   "alice-gh",
+			"provider_subject": "12345",
+			"claims":           map[string]interface{}{"orgs": []string{"acme"}},
+		},
+	}
+
+	var got AuditEvent
+	if err := json.Unmarshal(recordFor(t, event), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.Email != event.Email {
+		t.Errorf("email = %q, want %q", got.Email, event.Email)
+	}
+	if strings.Join(got.Groups, ",") != strings.Join(event.Groups, ",") {
+		t.Errorf("groups = %v, want %v", got.Groups, event.Groups)
+	}
+	if got.SessionID != event.SessionID || got.Provider != event.Provider ||
+		got.AuthMethod != event.AuthMethod || got.SourceIP != event.SourceIP ||
+		got.TargetHost != event.TargetHost || got.UserID != event.UserID {
+		t.Errorf("a scalar field was altered on an ordinary event: %+v", got)
+	}
+	if got.Metadata["provider_login"] != "alice-gh" {
+		t.Errorf("metadata.provider_login = %v, want alice-gh", got.Metadata["provider_login"])
+	}
+	if got.Metadata["claims"] == nil {
+		t.Error("metadata.claims was dropped from an ordinary event")
+	}
+	if got.Metadata[auditTruncationKey] != nil {
+		t.Errorf("an ordinary event was reported as truncated: %v", got.Metadata[auditTruncationKey])
+	}
+}
+
+// TestAProducerCannotForgeTheTruncationNote. The note is what tells an investigator
+// the record is incomplete, so a producer that could set it could also set it to
+// something reassuring. It is a reserved key.
+func TestAProducerCannotForgeTheTruncationNote(t *testing.T) {
+	record := recordFor(t, AuditEvent{
+		EventType: "authentication_success",
+		UserID:    "alice",
+		Email:     strings.Repeat("e", 8*1024),
+		Metadata: map[string]interface{}{
+			auditTruncationKey: "nothing was truncated, everything is fine",
+		},
+	})
+
+	var got AuditEvent
+	if err := json.Unmarshal(record, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	note, _ := json.Marshal(got.Metadata[auditTruncationKey])
+	if strings.Contains(string(note), "everything is fine") {
+		t.Errorf("a producer's own value survived under the reserved key: %s", note)
+	}
+	if !strings.Contains(string(note), "email") {
+		t.Errorf("the note does not mention the field that was actually truncated: %s", note)
+	}
+}
+
+// TestBoundingDoesNotBreakTheLandingContract: the bound runs before the
+// critical/queued split, so it is upstream of everything #91 and #94 established
+// about what an error means. A record that was bounded is still written, and a sink
+// that refuses it must still report that honestly.
+func TestBoundingDoesNotBreakTheLandingContract(t *testing.T) {
+	al, err := NewAuditLoggerWithOutputs(config.AuditConfig{Enabled: true},
+		&refusingOutput{err: fmt.Errorf("no space left on device")})
+	if err != nil {
+		t.Fatalf("NewAuditLoggerWithOutputs: %v", err)
+	}
+	t.Cleanup(func() { _ = al.Stop() })
+
+	writeErr := al.LogAuthEventErr(AuditEvent{
+		EventType: "authentication_success",
+		UserID:    "alice",
+		Email:     strings.Repeat("e", 128*1024),
+		Success:   true,
+	})
+	if writeErr == nil {
+		t.Fatal("a bounded record that no sink accepted was reported as written")
+	}
+	if RecordMayHaveLanded(writeErr) {
+		t.Errorf("err = %v claims the record may be readable; the sink reported taking none of it",
+			writeErr)
+	}
+}
+
+// TestTruncationNeverSplitsARune. json.Marshal answers invalid UTF-8 by
+// substituting U+FFFD, so a bound that cut mid-rune would silently edit a field
+// that is recorded precisely so it can be read back verbatim.
+func TestTruncationNeverSplitsARune(t *testing.T) {
+	// A 3-byte rune repeated, so that a naive cut at any byte offset not divisible by
+	// three lands inside one.
+	for _, pad := range []int{0, 1, 2} {
+		email := strings.Repeat("a", pad) + strings.Repeat("→", maxAuditStringBytes)
+		record := recordFor(t, AuditEvent{
+			EventType: "authentication_success",
+			UserID:    "alice",
+			Email:     email,
+		})
+		if !utf8.Valid(record) {
+			t.Errorf("pad %d: the record is not valid UTF-8", pad)
+		}
+		var got AuditEvent
+		if err := json.Unmarshal(record, &got); err != nil {
+			t.Fatalf("pad %d: unmarshal: %v", pad, err)
+		}
+		if strings.ContainsRune(got.Email, '�') {
+			t.Errorf("pad %d: the truncated email contains U+FFFD, so a rune was split and "+
+				"json.Marshal replaced it", pad)
+		}
+	}
+}

--- a/pkg/security/audit_perms.go
+++ b/pkg/security/audit_perms.go
@@ -1,0 +1,192 @@
+package security
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Opening the audit file the way every other file in this tree is opened — #106.
+//
+// Before this, newFileOutput was the only open in the tree with no O_NOFOLLOW, no
+// mode check and no directory check: pkg/config/secrets.go, pkg/config/config.go
+// and pkg/enrollment/store.go all have the three. It was also the only one that
+// *creates* a file, as root.
+//
+// What the three buy here is specific to what this sink is for. A symlink at
+// cfg.Path pointing at /dev/null makes every critical write succeed, so
+// LogAuthEventErr returns nil, the login is granted, and the trail is empty — the
+// fail-closed guarantee satisfied vacuously, which is the one failure mode of an
+// audit sink that nothing downstream can detect. O_CREAT|O_APPEND as root through
+// an unfollowed symlink is also an append to a file of somebody else's choosing;
+// records are single-line JSON so line injection into a file like cron.d is not
+// available, but disk-fill is.
+//
+// The reach is narrow under the shipped packaging — configs/systemd's
+// LogsDirectory is root:root 0750, and only root can plant a symlink in it, and
+// root can rewrite broker.yaml anyway. The check is here because "only root can do
+// it" was not accepted as an answer for the client secret, the mapper script or the
+// enrollment file, and an audit trail that can be silently voided is not the field
+// to start accepting it for.
+
+// auditFileMask is the permission bits the audit file may not have: write for
+// group or other.
+//
+// Read is deliberately absent, which is where this differs from pkg/config's rule
+// for a client secret (0o077) and matches pkg/enrollment's for the enrollment file
+// (0o022). A group-readable trail is a disclosure — it names local accounts,
+// provider logins and email addresses — but refusing to open one would refuse every
+// login on the host, because a critical record that cannot be written denies the
+// login it describes. Fail-closed makes an over-strict check on this path an
+// outage, and an outage is a worse answer to a disclosure than the disclosure.
+// Write is not a disclosure: it is the authority to forge or erase the record of an
+// access decision.
+const auditFileMask fs.FileMode = 0o022
+
+// auditDirMask is the permission bits the directory holding the audit file may not
+// have. The same bits, for the stronger reason pkg/enrollment gives: a directory is
+// write authority over every name in it, so a writable directory means the file can
+// be replaced — or, since this open creates, that the name can be a symlink before
+// the broker ever gets there.
+const auditDirMask fs.FileMode = 0o022
+
+// openAuditFile opens (creating if needed) the audit file at path, refusing a
+// symlink, a non-regular file, a file another local user could write, and a
+// directory another local user could write.
+//
+// The directory is checked first and by name, before the open, because this is the
+// one path in the tree that creates its file: checking afterwards would mean
+// creating a file in a directory this process has just decided it does not trust.
+func openAuditFile(path string) (*os.File, error) {
+	if err := checkAuditDirPerms(filepath.Dir(path)); err != nil {
+		return nil, err
+	}
+
+	// O_NOFOLLOW refuses a symlink in the same syscall as the open, rather than
+	// leaving a window in which one could appear between a check and the open (#96,
+	// #106). With O_CREAT the window matters more here than anywhere else: the file
+	// need not exist yet, so the name is one somebody else could reach first.
+	//
+	// O_NONBLOCK is for the FIFO case and is explained where it is defined — without
+	// it, a FIFO at this path hangs the open and the regular-file check below never
+	// runs.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|oNoFollow|oNonBlock, 0600) // #nosec G304 -- path comes from the broker's own root-owned config
+	if err != nil {
+		// Both flags report something other than what they refused: O_NOFOLLOW gives
+		// ELOOP, whose message describes a symbolic-link loop that is not there, and
+		// O_NONBLOCK on a readerless FIFO gives ENXIO, "device not configured". An
+		// operator debugging either message looks for the wrong thing, so say what is
+		// actually wrong. Lstat, not Stat: a symlink has to be reported as itself.
+		if fi, lerr := os.Lstat(path); lerr == nil {
+			if fi.Mode()&fs.ModeSymlink != 0 {
+				return nil, auditSymlinkError(path)
+			}
+			if !fi.Mode().IsRegular() {
+				return nil, notARegularAuditFileError(path, fi.Mode())
+			}
+		}
+		return nil, fmt.Errorf("open audit file %s: %w", path, err)
+	}
+
+	// Stat the open descriptor, not the path: what was checked has to be the same
+	// inode that is then written to, and a stat by name can be answered by one file
+	// and the writes served by another.
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("stat audit file %s: %w", path, err)
+	}
+	if err := checkAuditFilePerms(path, info); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+// checkAuditFilePerms refuses an audit file that is not a regular file, or that
+// another local user could write.
+//
+// Non-regular is its own case and not a pedantic one: a FIFO at this path blocks
+// the first critical write until something opens the read end, and since a critical
+// record is written on the login's own goroutine that is a login that never
+// returns. A character device — /dev/null being the obvious one — accepts every
+// write and keeps nothing, which is the vacuous fail-closed above.
+func checkAuditFilePerms(path string, info fs.FileInfo) error {
+	// Reachable when info came from Lstat; never when it came from a descriptor
+	// opened with O_NOFOLLOW. Kept for the same reason the other two copies keep it:
+	// the mode and owner that matter for a symlink would be the target's, and the
+	// target can be changed, by whoever owns the directory holding the link, without
+	// touching anything this function looked at.
+	if info.Mode()&fs.ModeSymlink != 0 {
+		return auditSymlinkError(path)
+	}
+	if !info.Mode().IsRegular() {
+		return notARegularAuditFileError(path, info.Mode())
+	}
+	if perm := info.Mode().Perm(); perm&auditFileMask != 0 {
+		return fmt.Errorf("%s is writable by group or other (mode %04o), so they can forge or erase "+
+			"the record of an access decision; run: chmod 640 %s", path, perm, path)
+	}
+	// Ownership matters as much as the mode: a 0600 file owned by someone else is a
+	// trail that user can rewrite whenever they like.
+	if uid, ok := fileOwner(info); ok {
+		if euid := os.Geteuid(); uid != 0 && uid != uint32(euid) { // #nosec G115 -- a uid fits a uid
+			return fmt.Errorf("%s is owned by uid %d, which is neither root nor this process "+
+				"(uid %d), so that user can rewrite the audit trail; run: chown root %s",
+				path, uid, euid, path)
+		}
+	}
+	return nil
+}
+
+// checkAuditDirPerms refuses a directory another local user could write to, and so
+// could put a symlink or a device at the audit file's name before the broker opens
+// it, or replace the file afterwards.
+func checkAuditDirPerms(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("stat audit directory %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory, so %s cannot be created in it", dir, dir)
+	}
+	perm := info.Mode().Perm()
+	// The sticky bit is the exception, and it is the reason /tmp can be shared: with
+	// it set, only the owner of a file may rename or unlink it, which is the attack
+	// the mode is being checked for. It does not stop another user creating a *new*
+	// name — which is why O_NOFOLLOW and the regular-file check above are what
+	// actually cover a relocated path under /tmp, and this exemption is not a hole.
+	if perm&auditDirMask != 0 && info.Mode()&fs.ModeSticky == 0 {
+		return fmt.Errorf("%s is writable by group or other (mode %04o), so the audit file in it can "+
+			"be replaced whatever its own mode is; run: chmod 750 %s", dir, perm, dir)
+	}
+	// A directory owned by another user is writable by them whatever its mode says,
+	// because they can chmod it.
+	if uid, ok := fileOwner(info); ok {
+		if euid := os.Geteuid(); uid != 0 && uid != uint32(euid) { // #nosec G115 -- a uid fits a uid
+			return fmt.Errorf("%s is owned by uid %d, which is neither root nor this process "+
+				"(uid %d), so that user can replace the audit file in it; run: chown root %s",
+				dir, uid, euid, dir)
+		}
+	}
+	return nil
+}
+
+// notARegularAuditFileError is shared by the two places that can notice: the open
+// itself, when O_NONBLOCK turned a FIFO into an error, and the check on the open
+// descriptor for everything that opens successfully. One message, so an operator
+// gets the same explanation either way.
+func notARegularAuditFileError(path string, mode fs.FileMode) error {
+	return fmt.Errorf("%s is not a regular file (mode %s); an audit sink has to be a file that "+
+		"keeps what is written to it — a device accepts records and discards them, which makes "+
+		"every login appear audited and leaves no trail, and a FIFO blocks the login whose record "+
+		"it is until something reads the other end", path, mode)
+}
+
+func auditSymlinkError(path string) error {
+	return fmt.Errorf("%s is a symlink; name the file itself, so that the file whose permissions "+
+		"are checked is the file the records are written to — a link to /dev/null makes every "+
+		"write succeed and keeps no trail, which is the one audit failure nothing downstream "+
+		"can detect", path)
+}

--- a/pkg/security/audit_perms_test.go
+++ b/pkg/security/audit_perms_test.go
@@ -1,0 +1,198 @@
+package security
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/oauth2-pam/pkg/config"
+)
+
+// The audit sink's own file checks — #106.
+//
+// pkg/config and pkg/enrollment each have symlink and permission tests for their
+// files. pkg/security had none, which is the other half of why this open went seven
+// rounds without O_NOFOLLOW: every test here uses t.TempDir(), and a directory this
+// process just created is never the directory the check is about.
+//
+// These go through NewAuditLogger rather than calling openAuditFile, because the
+// statement worth making is about the broker: a sink it cannot trust stops it
+// starting, rather than being accepted and quietly keeping nothing.
+
+// startWithAuditPath builds a logger writing to path and returns the error.
+func startWithAuditPath(t *testing.T, path string) error {
+	t.Helper()
+	al, err := NewAuditLogger(config.AuditConfig{
+		Enabled: true,
+		Outputs: []config.AuditOutput{{Type: "file", Path: path}},
+	})
+	if err == nil {
+		t.Cleanup(func() { _ = al.Stop() })
+	}
+	return err
+}
+
+// TestASymlinkedAuditPathIsRefused. A link to /dev/null is the case that matters:
+// every write to it succeeds, so LogAuthEventErr returns nil, every login is
+// granted, and there is no trail. The fail-closed guarantee is satisfied vacuously,
+// and nothing downstream can tell.
+func TestASymlinkedAuditPathIsRefused(t *testing.T) {
+	for name, target := range map[string]string{
+		"a link to /dev/null":      os.DevNull,
+		"a link to another file":   "", // filled in below, inside this test's dir
+		"a link to nothing at all": "/nonexistent/audit.log",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			if target == "" {
+				target = filepath.Join(dir, "real.log")
+				if err := os.WriteFile(target, nil, 0600); err != nil {
+					t.Fatalf("write target: %v", err)
+				}
+			}
+			link := filepath.Join(dir, "audit.log")
+			if err := os.Symlink(target, link); err != nil {
+				t.Fatalf("symlink: %v", err)
+			}
+
+			err := startWithAuditPath(t, link)
+			if err == nil {
+				t.Fatal("the broker started with a symlinked audit path; a link to /dev/null makes " +
+					"every record appear written and keeps none")
+			}
+			// The message has to name the actual problem. O_NOFOLLOW reports ELOOP, whose
+			// text describes a symbolic-link loop that is not there, and an operator
+			// debugging that message looks for the wrong thing.
+			if !strings.Contains(err.Error(), "symlink") {
+				t.Errorf("err = %v, which does not say the path is a symlink", err)
+			}
+		})
+	}
+}
+
+// TestAnAuditPathThatKeepsNothingIsRefused: /dev/null named directly, with no
+// symlink involved. O_NOFOLLOW says nothing about this one — it is the regular-file
+// check that does, and without it the sink is the same vacuous success.
+func TestAnAuditPathThatKeepsNothingIsRefused(t *testing.T) {
+	if _, err := os.Stat(os.DevNull); err != nil {
+		t.Skipf("no %s on this platform", os.DevNull)
+	}
+	err := startWithAuditPath(t, os.DevNull)
+	if err == nil {
+		t.Fatal("the broker started with its audit trail pointed at /dev/null")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("err = %v, which does not say why a device is not a sink", err)
+	}
+}
+
+// TestAnAuditFileOtherUsersCanWriteIsRefused. Write on the trail is the authority to
+// forge or erase the record of an access decision, which outranks a start-up failure
+// the operator can fix with one chmod.
+func TestAnAuditFileOtherUsersCanWriteIsRefused(t *testing.T) {
+	for name, mode := range map[string]os.FileMode{
+		"group-writable": 0o660,
+		"world-writable": 0o666,
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "audit.log")
+			if err := os.WriteFile(path, nil, mode); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			// WriteFile applies the umask, so the bits under test have to be set after it.
+			if err := os.Chmod(path, mode); err != nil {
+				t.Fatalf("chmod: %v", err)
+			}
+
+			err := startWithAuditPath(t, path)
+			if err == nil {
+				t.Fatalf("the broker started with a %04o audit file", mode)
+			}
+			if !strings.Contains(err.Error(), "writable by group or other") {
+				t.Errorf("err = %v, which does not say the mode is the problem", err)
+			}
+		})
+	}
+}
+
+// TestAnAuditDirectoryOtherUsersCanWriteIsRefused. The directory is checked before
+// the file is created, because this is the one open in the tree that creates its
+// file: a name in a directory somebody else can write is a name they can get to
+// first.
+func TestAnAuditDirectoryOtherUsersCanWriteIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	path := filepath.Join(dir, "audit.log")
+	err := startWithAuditPath(t, path)
+	if err == nil {
+		t.Fatal("the broker started with its audit file in a world-writable directory")
+	}
+	if !strings.Contains(err.Error(), "writable by group or other") {
+		t.Errorf("err = %v, which does not say the directory is the problem", err)
+	}
+	// And it refused before creating anything: a file created in a directory this
+	// process has decided it does not trust is a file it should not have made.
+	if _, statErr := os.Lstat(path); statErr == nil {
+		t.Error("the audit file was created in the directory that was then rejected")
+	}
+}
+
+// TestAnOrdinaryAuditPathIsAccepted is the control, and it is the assertion that
+// keeps this from being a fix that refuses real installations. Three shapes an
+// operator really has:
+//
+//   - the shipped one: a fresh 0750 directory and a file that does not exist yet;
+//   - a file already there from a previous run;
+//   - a 0640 file, group-readable so that an operators group can tail it. Read is
+//     deliberately allowed — refusing it would refuse every login on the host,
+//     because a critical record that cannot be written denies the login it
+//     describes, and an outage is a worse answer to a disclosure than the
+//     disclosure.
+func TestAnOrdinaryAuditPathIsAccepted(t *testing.T) {
+	t.Run("a path that does not exist yet", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.Chmod(dir, 0o750); err != nil {
+			t.Fatalf("chmod: %v", err)
+		}
+		if err := startWithAuditPath(t, filepath.Join(dir, "audit.log")); err != nil {
+			t.Fatalf("the shipped shape was refused: %v", err)
+		}
+	})
+
+	for name, mode := range map[string]os.FileMode{
+		"an existing 0600 file": 0o600,
+		"an existing 0640 file": 0o640,
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "audit.log")
+			if err := os.WriteFile(path, []byte("{}\n"), mode); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := os.Chmod(path, mode); err != nil {
+				t.Fatalf("chmod: %v", err)
+			}
+			if err := startWithAuditPath(t, path); err != nil {
+				t.Fatalf("a %04o audit file was refused: %v", mode, err)
+			}
+		})
+	}
+}
+
+// TestAStickyDirectoryIsAccepted: /tmp is 1777 and shared, and the sticky bit is why
+// that is not a hole — with it set, only a file's owner may rename or unlink it.
+// What it does not stop is another user creating a name the broker has not created
+// yet, which is what O_NOFOLLOW and the regular-file check cover; the two tests
+// above are the ones that hold for a relocated path under /tmp.
+func TestAStickyDirectoryIsAccepted(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, os.ModeSticky|0o777); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if err := startWithAuditPath(t, filepath.Join(dir, "audit.log")); err != nil {
+		t.Fatalf("a sticky shared directory was refused: %v", err)
+	}
+}

--- a/pkg/security/audit_perms_unix_test.go
+++ b/pkg/security/audit_perms_unix_test.go
@@ -1,0 +1,45 @@
+//go:build unix
+
+package security
+
+import (
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestAFifoAuditPathIsRefused. The other half of the regular-file check, and the
+// worse half operationally: a critical record is written and fsynced on the login's
+// own goroutine, so a FIFO with nothing reading it does not lose the record — it
+// blocks the login, and every login after it, for as long as the pipe is full.
+//
+// Tagged unix because mkfifo is; the check it exercises is not.
+func TestAFifoAuditPathIsRefused(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.log")
+	if err := syscall.Mkfifo(path, 0600); err != nil {
+		t.Skipf("mkfifo: %v", err)
+	}
+
+	// Behind a timeout because the failure mode of removing O_NONBLOCK is a hang, not
+	// a wrong answer: an open of a FIFO for writing waits for a reader, and there is
+	// no deadline anywhere between here and NewAuditLogger's caller. A test that hung
+	// would take the whole package down with the 10-minute panic and name the wrong
+	// test as the cause.
+	done := make(chan error, 1)
+	go func() { done <- startWithAuditPath(t, path) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("the broker started with its audit trail pointed at a FIFO")
+		}
+		if !strings.Contains(err.Error(), "not a regular file") {
+			t.Errorf("err = %v, which does not say why a FIFO is not a sink", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("opening the FIFO blocked: the open is waiting for a reader, so a broker configured " +
+			"this way never finishes starting")
+	}
+}

--- a/pkg/security/fileowner_other.go
+++ b/pkg/security/fileowner_other.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package security
+
+import "io/fs"
+
+// fileOwner cannot determine ownership on this platform and says so rather than
+// guessing. A false "owned by root" would turn the ownership half of
+// checkAuditFilePerms into a rubber stamp; the permission-bit half still applies.
+func fileOwner(_ fs.FileInfo) (uint32, bool) { return 0, false }

--- a/pkg/security/fileowner_unix.go
+++ b/pkg/security/fileowner_unix.go
@@ -1,0 +1,19 @@
+//go:build unix
+
+package security
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+// fileOwner reports the uid owning info. The Stat_t assertion is the only way to
+// ask: io/fs deliberately does not model ownership, because not every filesystem
+// has it.
+func fileOwner(info fs.FileInfo) (uint32, bool) {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return st.Uid, true
+}

--- a/pkg/security/nofollow_other.go
+++ b/pkg/security/nofollow_other.go
@@ -1,0 +1,15 @@
+//go:build !unix
+
+package security
+
+// oNoFollow has no equivalent on this platform, so the open cannot refuse a symlink
+// and the checks in checkAuditFilePerms are all there is: enough to reject a symlink
+// already in place, not enough to win a race against one appearing between the check
+// and the write. The broker is the counterpart of a PAM module and only ever runs on
+// unix; this exists so the package still builds elsewhere, as fileowner_other.go
+// does.
+const oNoFollow = 0
+
+// oNonBlock likewise has no equivalent here. A platform without O_NONBLOCK is a
+// platform without the FIFO semantics that make it necessary.
+const oNonBlock = 0

--- a/pkg/security/nofollow_unix.go
+++ b/pkg/security/nofollow_unix.go
@@ -1,0 +1,32 @@
+//go:build unix
+
+package security
+
+import "syscall"
+
+// oNoFollow makes an open fail rather than follow a symlink at the last path
+// component. There is no portable spelling of it in the os package, for the same
+// reason fileOwner needs a build-tagged file: not every platform has it.
+//
+// This is the third copy of these two lines — pkg/config has one for its secret
+// files and pkg/enrollment one for the enrollment file. The masks the three
+// packages apply genuinely differ (0o077 for a secret, 0o022 for the other two), so
+// the checks are not one function with a parameter, but the syscall flag is. A
+// fourth copy would be the point at which to extract an internal package; three,
+// each two lines, is cheaper than a new dependency edge between packages that
+// currently have none.
+const oNoFollow = syscall.O_NOFOLLOW
+
+// oNonBlock makes an open of a FIFO return rather than wait for a peer.
+//
+// It is here for one case, and the case is not hypothetical: an open of a FIFO for
+// writing blocks until something opens the read end, so a FIFO at the audit path
+// would hang the open — inside NewAuditLogger, before the broker has a socket, with
+// no timeout anywhere. Without this flag the regular-file check in
+// checkAuditFilePerms could never run on a FIFO, because the open it is meant to
+// vet never returns.
+//
+// On a regular file the flag has no effect, which is what makes it safe to leave set
+// for the lifetime of the descriptor: POSIX defines O_NONBLOCK's meaning for FIFOs,
+// sockets and some devices, and regular-file reads and writes ignore it.
+const oNonBlock = syscall.O_NONBLOCK

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -83,9 +83,19 @@ else
     install -m 0600 -o root -g root configs/example.yaml "$CONFDIR/broker.yaml"
     echo "  wrote $CONFDIR/broker.yaml from the example — edit it before starting the broker"
 
-    # Fill in the encryption key now. Left unset, secure_token_storage does
-    # nothing and access tokens sit in the broker's memory in the clear; and a
-    # generated key beats whatever an administrator would type by ~200 bits.
+    # Fill in the encryption key now, but understand what it does and does not
+    # buy. Left unset, tokens are NOT in the clear: NewTokenManager falls back to
+    # security.NewEphemeralEncryption() and encrypts under a per-process key, and
+    # only secure_token_storage: false gives plaintext. Nothing is written to
+    # disk either, so a key that dies with the process loses nothing on restart —
+    # the tokens die with it.
+    #
+    # What this line buys is that the key is stated in the config rather than left
+    # to a fallback: it is visible, rotatable, and does not change meaning if that
+    # default ever does. And if a key is going to be there at all, a generated one
+    # beats whatever an administrator would type by ~200 bits.
+    #
+    # This comment claimed an unset key left tokens in the clear until #109.
     key=$("$PREFIX/bin/oauth2-pam-admin" gen-key) || die "gen-key failed"
     # The sed script arrives on stdin rather than in argv. /proc/<pid>/cmdline is
     # world-readable on Linux, so a key passed as an argument is recoverable by

--- a/test/cbridge/mutations.sh
+++ b/test/cbridge/mutations.sh
@@ -50,6 +50,14 @@ cp cmd/pam-module/cgo_bridge.h "$WORK/cmd/pam-module/"
 cp test/cbridge/cbridge_test.c "$WORK/test/cbridge/"
 
 failures=0
+mutations=0
+
+# DOCUMENTED_MUTATIONS is the number README.md and SECURITY.md say this script
+# reintroduces. Both said six for three releases while the real number grew to 25
+# (#109), because nothing connected the prose to the script. The count is asserted at
+# the end of the run: adding a case fails here until the two documents are updated,
+# which is the only mechanism that keeps a number in prose honest.
+DOCUMENTED_MUTATIONS=25
 
 # run <name> <fail|pass> [perl-expression]
 #
@@ -59,6 +67,8 @@ failures=0
 # reported as a setup failure rather than a pass.
 run() {
     local name=$1 expect=$2 expr=${3:-}
+
+    [ "$expect" = "fail" ] && mutations=$((mutations + 1))
 
     cp "$BRIDGE" "$WORK/$BRIDGE"
 
@@ -301,8 +311,14 @@ run "oversized QR art is truncated rather than dropped" fail \
     '$n = s/(if \(len >= dst_size\) \{).*?return;/$1 len = dst_size - 1; memcpy(dst, val, len); dst[len] = 0; return;/s'
 
 echo
+if [ "$mutations" -ne "$DOCUMENTED_MUTATIONS" ]; then
+    echo "this script reintroduces $mutations defects; README.md and SECURITY.md say" \
+         "$DOCUMENTED_MUTATIONS. Update both, and DOCUMENTED_MUTATIONS above, so the" \
+         "documented count is the real one (#109)."
+    failures=$((failures + 1))
+fi
 if [ "$failures" -ne 0 ]; then
     echo "$failures case(s) failed — a regression test is not protecting what it claims to"
     exit 1
 fi
-echo "every mutation was caught"
+echo "every mutation was caught ($mutations of them)"


### PR DESCRIPTION
Closes #104, closes #105, closes #106, closes #107, closes #108, closes #109.

Round eight of the adversarial review. Six issues. The two that matter share a shape the previous seven rounds did not look for: **a protection that exists on one path and not on the path beside it**, with nothing in either place saying the other exists.

## #104 — the audit record was bounded on the way to the terminal and unbounded on the way to the file

Every provider-chosen string reaching a pre-auth tty has a byte cap. The same strings — provider login, email, mapped local user, the group list, a provider's error message — reached `LogAuthEventErr` at whatever length they arrived. An identity with a megabyte of groups is a megabyte per login attempt, unauthenticated, from anything that can reach the socket, in the one file the fail-closed rule says a login cannot proceed without: fill the filesystem and the broker grants no logins at all.

Records are now bounded on the way in — 1 KiB per string, 256 B per group name, 128 groups, 32 metadata keys, 64 KiB per record — truncated at rune boundaries so the record stays valid UTF-8, and marked with an `audit_truncated` field rather than shortened silently, because a trail that quietly shortens a group name lies about who was in what. A record that still cannot be bounded is replaced by a minimal one naming the event, the decision and the account: under a fail-closed rule the alternative to a degraded record is a refused login.

## #105 — the reply filter kept its own narrower rule, and its test could not have caught it

`boundedReplyField` stripped C0 and DEL. The prompt sanitizer, three rounds of hardening older, also strips C1 (U+0080–U+009F), U+2028 and U+2029 — `encoding/json` does not escape U+009B and U+009B **is** CSI to a terminal decoding UTF-8. So a group name carrying a bare C1 was filtered for the prompt and forwarded intact to the audit file, journald and the admin console.

The test meant to hold that line asserted `r < 0x20 || r == 0x7f` — the filter's own former condition, restated — over input containing no C1 at all. A test that restates the implementation's predicate cannot fail. The filter now calls the shared `isDisallowedInPrompt`; the test calls the shared `assertNoDisallowedRunes`, which additionally requires valid UTF-8 and so closes the raw-`0x9b` case where a lone byte ranges as U+FFFD. A second test walks an authorized reply by reflection and asserts on every string in it, so a field added later is covered without anyone editing this test.

## #106 — the audit file was opened with no check on what it was or who could write it

The secret file, the mapper script and the enrollment file each refuse a symlink, require a regular file, and require that neither the file nor its directory be writable by anyone but the owner. The audit sink had none of it, and `path` was not required to be absolute.

The symlink case is the one that matters: point the path at `/dev/null` and every write succeeds, so "the record was written" is satisfied by a sink that keeps nothing — every login granted, trail empty. That is the single audit failure nothing downstream can detect, because every mechanism built to detect one is watching for an error.

`openAuditFile` checks the directory **before** the `O_CREAT` open (this is the tree's only creating open, so checking afterwards means creating a file in a directory the process has just decided it does not trust), opens with `O_NOFOLLOW`, and verifies mode and owner from the descriptor. The mask is write-only, `0o022`, not the secret file's `0o077`: a group-readable trail at 0640 is a deliberate arrangement, and refusing it would refuse every login on the host — an outage is a worse answer to a disclosure than the disclosure.

`O_NONBLOCK` is part of the fix, not an incidental flag. An `O_WRONLY` open of a FIFO with no reader blocks forever, so without it the regular-file check is unreachable on exactly the path it exists to refuse, and the test for it hangs the suite instead of failing. The mutation check confirmed that: with the flag removed, the FIFO test's 10-second guard fires.

## #107, #108, #109 — documentation read against the code

- **#107** the README named `mapper.enrollment_file` as the key that switches tier 0 on. It is `mapper.enrollment_enabled`. Following the README gave "at least one tier must be configured", and adding a rule to get past that gave a broker where tier 0 was never consulted while `oauth2-pam-enroll` reported success. `configs/example.yaml` is protected by a load-and-validate test; the prose was not. It is now: every dotted key in backticks under a real config section, across `README.md`, `SECURITY.md` and `docs/*.md`, must resolve to a real `mapstructure` tag, with a control test that fails if the scan stops finding keys.
- **#108** `configs/example.yaml` named `RATE_LIMITED` where `max_concurrent_auths` returns `AUTH_LIMIT_REACHED`. The two are different answers — one is retryable, the other terminal, and they map to different PAM results. Nothing mechanical catches this, since the wrong name is itself a real constant; the comment says so.
- **#109** a cluster of claims false against the code. Two understated the project, which in `SECURITY.md` is its own defect: CodeQL *does* analyze the C (a `go` + `c-cpp` matrix that compiles the bridge under the extractor), and the secret file's directory *is* checked. Three overstated it: a CodeQL finding does not fail the run and never did, the enrollment file's mask is write-only `0o022` rather than "0600 or tighter", and CI runs on pushes to `main` plus PRs rather than every push. The C bridge mutation count was documented as six and is 25 — so `test/cbridge/mutations.sh` now counts its own `expect fail` cases and fails if the total is not the documented one, which is the only one of these that can drift again silently.

Closed with #109: `TokenManager.Stop` now calls `Encryption.Destroy`, whose doc said "call it at shutdown" and which had no non-test caller; `enrollment.Unvalidated` is unexported, having stayed at zero external callers (which was the outcome it was watching for, so an exported sentinel is now only an invitation to a first one); and a malformed `security.token_encryption_key` is rejected even when `secure_token_storage: false`, where it used to wait in the file for whoever turned storage back on and then blamed that change.

## Upgrade notes

Three startup errors, no silent changes:

- `audit.outputs[].path` must be absolute — under systemd the cwd is `/`, so a relative path named a file nobody meant.
- The audit file and its directory must not be writable by group or other, must not be a symlink, and must be a regular file. Group *read* stays allowed.
- A malformed `security.token_encryption_key` is rejected regardless of `secure_token_storage`.

## Verification

- `gofmt -l`, `go vet ./...`, `go test -race ./...` clean
- `golangci-lint run` — 0 issues
- `make security` (gosec) — 13 findings, all in pre-existing paths; nothing new, and `audit_perms.go`'s single `#nosec G304` is annotated with its reason
- `make verify-linux` — 226 C checks, 0 failures; all six `pam_sm_*` entry points present, nothing beyond them exported
- `make test-cbridge-mutations` — every mutation caught (25 of them, now asserted against the documented count)
- `make test-integration` — 12 of 12 container cases pass

Each fix was mutation-checked by hand as well: reverting the C1 policy, the `O_NONBLOCK` flag, the `Destroy` call and the doc-key scan each fails the test written for it.